### PR TITLE
Fix download speed reporting and use a progress bar when possible

### DIFF
--- a/examples/query.rs
+++ b/examples/query.rs
@@ -4,7 +4,7 @@ use tvrank::imdb::{Imdb, ImdbQuery};
 
 fn main() -> tvrank::Res<()> {
   let cache_dir = tempfile::Builder::new().prefix("tvrank_").tempdir()?;
-  let imdb = Imdb::new(cache_dir.path(), false, &|_| {})?;
+  let imdb = Imdb::new(cache_dir.path(), false, &|_, _| {})?;
 
   let title = "city of god";
   let year = 2002;

--- a/examples/query.rs
+++ b/examples/query.rs
@@ -4,7 +4,7 @@ use tvrank::imdb::{Imdb, ImdbQuery};
 
 fn main() -> tvrank::Res<()> {
   let cache_dir = tempfile::Builder::new().prefix("tvrank_").tempdir()?;
-  let imdb = Imdb::new(cache_dir.path(), false, &mut |_| {})?;
+  let imdb = Imdb::new(cache_dir.path(), false, &|_| {})?;
 
   let title = "city of god";
   let year = 2002;

--- a/src/imdb/db.rs
+++ b/src/imdb/db.rs
@@ -70,20 +70,17 @@ impl Db {
     mut basics_reader: R2,
     mut movies_db_writer: W1,
     mut series_db_writer: W2,
-    progress_fn: &mut dyn FnMut(u64),
   ) -> Res<()> {
-    let ratings = Ratings::from_tsv(ratings_reader, progress_fn)?;
+    let ratings = Ratings::from_tsv(ratings_reader)?;
 
     let mut line = String::new();
 
     // Skip the first line.
-    let bytes = basics_reader.read_line(&mut line)?;
-    progress_fn(bytes as u64);
+    basics_reader.read_line(&mut line)?;
     line.clear();
 
     loop {
       let bytes = basics_reader.read_line(&mut line)?;
-      progress_fn(bytes as u64);
 
       if bytes == 0 {
         break;
@@ -371,13 +368,12 @@ mod test_db {
 
     let mut movies_storage = Vec::new();
     let mut series_storage = Vec::new();
-    Db::to_binary(ratings_reader, basics_reader, &mut movies_storage, &mut series_storage, &mut |_| {})
-      .unwrap();
+    Db::to_binary(ratings_reader, basics_reader, &mut movies_storage, &mut series_storage).unwrap();
 
     let mut basics_reader = make_basics_reader();
     let ratings_reader = make_ratings_reader();
 
-    let ratings = Ratings::from_tsv(ratings_reader, &mut |_| {}).unwrap();
+    let ratings = Ratings::from_tsv(ratings_reader).unwrap();
 
     let mut basics_data = String::new();
     basics_reader.read_to_string(&mut basics_data).unwrap();

--- a/src/imdb/mod.rs
+++ b/src/imdb/mod.rs
@@ -3,6 +3,7 @@
 mod db;
 mod error;
 mod genre;
+mod progress;
 mod ratings;
 mod service;
 mod title;

--- a/src/imdb/progress.rs
+++ b/src/imdb/progress.rs
@@ -1,0 +1,20 @@
+use std::io::Read;
+
+pub struct Progress<'a, R> {
+  inner: R,
+  progress_fn: &'a dyn Fn(u64),
+}
+
+impl<'a, R: Read> Progress<'a, R> {
+  pub fn new(inner: R, progress_fn: &'a dyn Fn(u64)) -> Self {
+    Self { inner, progress_fn }
+  }
+}
+
+impl<'a, R: Read> Read for Progress<'a, R> {
+  fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+    let bytes = self.inner.read(buf)?;
+    (self.progress_fn)(bytes as u64);
+    Ok(bytes)
+  }
+}

--- a/src/imdb/progress.rs
+++ b/src/imdb/progress.rs
@@ -2,11 +2,11 @@ use std::io::Read;
 
 pub struct Progress<'a, R> {
   inner: R,
-  progress_fn: &'a dyn Fn(u64),
+  progress_fn: &'a dyn Fn(Option<u64>, u64),
 }
 
 impl<'a, R: Read> Progress<'a, R> {
-  pub fn new(inner: R, progress_fn: &'a dyn Fn(u64)) -> Self {
+  pub fn new(inner: R, progress_fn: &'a dyn Fn(Option<u64>, u64)) -> Self {
     Self { inner, progress_fn }
   }
 }
@@ -14,7 +14,7 @@ impl<'a, R: Read> Progress<'a, R> {
 impl<'a, R: Read> Read for Progress<'a, R> {
   fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
     let bytes = self.inner.read(buf)?;
-    (self.progress_fn)(bytes as u64);
+    (self.progress_fn)(None, bytes as u64);
     Ok(bytes)
   }
 }

--- a/src/imdb/ratings.rs
+++ b/src/imdb/ratings.rs
@@ -101,7 +101,7 @@ impl DerefMut for Ratings {
 }
 
 impl Ratings {
-  pub(crate) fn from_tsv<R: BufRead>(mut reader: R, progress_fn: &mut dyn FnMut(u64)) -> Res<Self> {
+  pub(crate) fn from_tsv<R: BufRead>(mut reader: R) -> Res<Self> {
     // TODO: See if we can use byte vectors instead of strings. Ultimately we end up
     // parsing bytes rather than strings, and when we need strings, we already know they
     // are valid UTF-8 because we trust the source.
@@ -110,13 +110,11 @@ impl Ratings {
     let mut line = String::new();
 
     // Skip the first line.
-    let bytes = reader.read_line(&mut line)?;
-    progress_fn(bytes as u64);
+    reader.read_line(&mut line)?;
     line.clear();
 
     loop {
       let bytes = reader.read_line(&mut line)?;
-      progress_fn(bytes as u64);
 
       if bytes == 0 {
         break;
@@ -172,7 +170,7 @@ mod tests_ratings {
   #[test]
   fn test_ratings_csv() {
     let reader = make_ratings_reader();
-    let ratings = Ratings::from_tsv(reader, &mut (|_| {})).unwrap();
+    let ratings = Ratings::from_tsv(reader).unwrap();
     assert_eq!(ratings.len(), 10);
 
     let id = TitleId::try_from("tt0000001".as_bytes()).unwrap();

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -2,15 +2,15 @@
 
 use indicatif::{ProgressBar, ProgressStyle};
 
-// pub fn create_progress_bar(msg: String, len: u64) -> ProgressBar {
-//   let bar = ProgressBar::new(len).with_style(ProgressStyle::default_bar().template(
-//     "{msg}: {bar:40.cyan/blue} {percent:>3}%  {bytes:>9}/{total_bytes} {bytes_per_sec:>10} {elapsed:>4} ETA: {eta:>4}",
-//   ));
+pub fn create_progress_bar(msg: String, len: u64) -> ProgressBar {
+  let bar = ProgressBar::new(len).with_style(ProgressStyle::default_bar().template(
+    "{msg}: {bar:40.cyan/blue} {percent:>3}%  {bytes:>9}/{total_bytes} {bytes_per_sec:>10} {elapsed:>4} ETA: {eta:>4}",
+  ));
 
-//   bar.set_draw_rate(2);
-//   bar.set_message(leak_string(msg));
-//   bar
-// }
+  bar.set_draw_rate(2);
+  bar.set_message(leak_string(msg));
+  bar
+}
 
 pub fn create_progress_spinner(msg: String) -> ProgressBar {
   let bar = ProgressBar::new_spinner().with_style(


### PR DESCRIPTION
- Fix progress reporting to report the actual download speed instead of data rate after decompression.
- Display a progress bar instead of a spinner when download sizes are known, and fallback to a spinner otherwise.

Closes #12 