### PR TITLE
Fix GitPod toolchain setup

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,12 +1,22 @@
 # See documentation: https://www.gitpod.io/docs/config-gitpod-file
-
 ---
 tasks:
-  - init: |
+  - before: |
+      # Install mob tool.
       curl -sL install.mob.sh | sudo sh
-      rustup install stable
-      rustup component add rustfmt clippy rust-src rust-docs
-      rustup component add rls rust-analysis llvm-tools-preview
+
+      # GitPod's rustup wrapper seems not to work with current
+      # versions of rustup. Disable wrapper and unset CARGO_HOME
+      # while installing the current Rust stable toolchain
+      # and additional components.
+      mv ~/.cargo/bin/rustup ~/.cargo/bin/rustup.script
+      mv ~/.cargo/bin/rustup.main ~/.cargo/bin/rustup
+      CARGO_HOME= rustup toolchain install stable
+      CARGO_HOME= rustup component add rust-docs llvm-tools-preview
+      mv ~/.cargo/bin/rustup ~/.cargo/bin/rustup.main
+      mv ~/.cargo/bin/rustup.script ~/.cargo/bin/rustup
+  - init: |
+      # Build workspace.
       cargo build
 
 vscode:


### PR DESCRIPTION
Currently, the Rust toolchain installation fails when opening the repository in GitPod.

This PR fixes the issue by introducing the following changes:
- GitPod's rustup wrapper seems not to work with current versions of
  rustup. Disable wrapper and unset CARGO_HOME while installing the
  current Rust stable toolchain and additional components.
- Remove components from "component add" command that are already
  installed in the current GitPod image.
- Move installation commands from "init" to "before", so they will be
  executed when resuming a stopped workspace as well.

Run GitPod on the main branch: https://gitpod.io/#https://github.com/fredmorcos/tvrank
Run GitPod on the PR branch: https://gitpod.io/#https://github.com/mob-programming-meetup/tvrank/tree/fix-gitpod