### PR TITLE
Change from structopt to clap v3.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,15 +27,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "arrayref"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -155,17 +146,32 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "2.34.0"
+version = "3.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+checksum = "d8c93436c21e4698bacadf42917db28b23017027a4deccb35dbe47a7e7840123"
 dependencies = [
- "ansi_term",
  "atty",
  "bitflags",
+ "clap_derive",
+ "indexmap",
+ "lazy_static",
+ "os_str_bytes",
  "strsim",
+ "termcolor",
  "textwrap",
- "unicode-width",
- "vec_map",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da95d038ede1a964ce99f49cbe27a7fb538d1da595e4b4f70b8c8f338d17bf16"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -556,12 +562,9 @@ checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 
 [[package]]
 name = "heck"
-version = "0.3.3"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
-]
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
 
 [[package]]
 name = "hermit-abi"
@@ -920,6 +923,15 @@ dependencies = [
  "libc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "os_str_bytes"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -1333,33 +1345,9 @@ dependencies = [
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "structopt"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
-dependencies = [
- "clap",
- "lazy_static",
- "structopt-derive",
-]
-
-[[package]]
-name = "structopt-derive"
-version = "0.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
-dependencies = [
- "heck",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
-]
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
@@ -1418,12 +1406,9 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.11.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
-]
+checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "tinyvec"
@@ -1524,6 +1509,7 @@ version = "0.7.4"
 dependencies = [
  "aho-corasick",
  "atoi",
+ "clap",
  "csv",
  "derive_more",
  "deunicode",
@@ -1544,7 +1530,6 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
- "structopt",
  "tempfile",
  "truncatable",
  "walkdir",
@@ -1564,12 +1549,6 @@ checksum = "d54590932941a9e9266f0832deed84ebe1bf2e4c9e4a3554d393d18f5e854bf9"
 dependencies = [
  "tinyvec",
 ]
-
-[[package]]
-name = "unicode-segmentation"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e8820f5d777f6224dc4be3632222971ac30164d4a258d595640799554ebfd99"
 
 [[package]]
 name = "unicode-width"
@@ -1606,12 +1585,6 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ path = "src/main.rs"
 [dependencies]
 env_logger = "0.8"
 log = "0.4"
-structopt = "0.3"
+clap = { version = "3.1.6", features = ["derive"] }
 derive_more = "0.99"
 # derive-new = "0.5"
 enum-utils = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ path = "src/main.rs"
 [dependencies]
 env_logger = "0.8"
 log = "0.4"
-clap = { version = "3.1.6", features = ["derive"] }
+clap = { version = "3.1", features = ["derive"] }
 derive_more = "0.99"
 # derive-new = "0.5"
 enum-utils = "0.1"

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@ mod ui;
 
 use crate::print::{JsonPrinter, OutputFormat, Printer, TablePrinter, YamlPrinter};
 use atoi::atoi;
-use clap::{Args, Parser, Subcommand};
+use clap::Parser;
 use derive_more::Display;
 use directories::ProjectDirs;
 use humantime::format_duration;
@@ -104,7 +104,7 @@ fn create_project() -> Res<ProjectDirs> {
   }
 }
 
-#[derive(Debug, Args)]
+#[derive(Debug, clap::Args)]
 struct GeneralOpts {
   /// Force updating internal databases
   #[clap(short, long)]
@@ -119,7 +119,7 @@ struct GeneralOpts {
   verbose: u8,
 }
 
-#[derive(Debug, Args)]
+#[derive(Debug, clap::Args)]
 struct SearchOpts {
   /// Sort by year/rating/title instead of rating/year/title
   #[clap(short = 'y', long)]
@@ -134,7 +134,7 @@ struct SearchOpts {
   output: OutputFormat,
 }
 
-#[derive(Debug, Parser)]
+#[derive(Debug, clap::Parser)]
 #[clap(about = "Query information about movies and series")]
 #[clap(author = "Fred Morcos <fm@fredmorcos.com>")]
 struct Opt {
@@ -145,7 +145,7 @@ struct Opt {
   command: Command,
 }
 
-#[derive(Debug, Subcommand)]
+#[derive(Debug, clap::Subcommand)]
 enum Command {
   /// Lookup a single title using "KEYWORDS" or "TITLE (YYYY)"
   Title {

--- a/src/print.rs
+++ b/src/print.rs
@@ -1,32 +1,16 @@
-use crate::TvRankErr;
 use humantime::format_duration;
 use prettytable::{color, format, Attr, Cell, Row, Table};
 use reqwest::Url;
 use serde::Serialize;
-use std::error::Error;
-use std::str::FromStr;
 use truncatable::Truncatable;
 use tvrank::imdb::{ImdbQuery, ImdbTitle};
 use tvrank::Res;
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, clap::ArgEnum)]
 pub enum OutputFormat {
   Json,
   Table,
   Yaml,
-}
-
-impl FromStr for OutputFormat {
-  type Err = Box<dyn Error>;
-
-  fn from_str(format: &str) -> Result<Self, Self::Err> {
-    match format {
-      "json" => Ok(OutputFormat::Json),
-      "table" => Ok(OutputFormat::Table),
-      "yaml" => Ok(OutputFormat::Yaml),
-      _ => TvRankErr::unsupported_output(),
-    }
-  }
 }
 
 #[derive(Serialize)]


### PR DESCRIPTION
Version 3 of clap has a derive interface which handles most of
structopt. It is accessed with `features = ["derive"]`.

Changed all occurrences of `structopt` macro to `clap`

Changed `StructOpt` traits to `Args`, `Parser`, or `Subcommand`

Added `arg_enum` attribute to which obviates `possible_values`

The `OutputFormat` enum derives `clap::ArgEnum` which obviates
`Copy`. Now it no longer requires `FromStr` or `TvRankErr`