### PR TITLE
Fix search results when keywords contain "the" as part of another word

### DIFF
--- a/src/imdb/db.rs
+++ b/src/imdb/db.rs
@@ -6,6 +6,7 @@ use crate::imdb::title::TsvAction;
 use crate::imdb::title_id::TitleId;
 use crate::Res;
 use aho_corasick::AhoCorasickBuilder;
+use aho_corasick::MatchKind as ACMatchKind;
 use derive_more::{Display, From, Into};
 use deunicode::deunicode;
 use fnv::{FnvHashMap, FnvHashSet};
@@ -311,7 +312,7 @@ impl<C> DbImpl<C> {
   /// # Arguments
   /// * `keywords` - Keywords to be searched in the titles
   fn cookies_by_keywords<'a, 'k>(&'a self, keywords: &'k [&str]) -> impl Iterator<Item = &'a C> {
-    let searcher = AhoCorasickBuilder::new().build(keywords);
+    let searcher = AhoCorasickBuilder::new().match_kind(ACMatchKind::LeftmostFirst).build(keywords);
     let keywords_len = keywords.len();
     self
       .by_title
@@ -333,7 +334,7 @@ impl<C> DbImpl<C> {
     keywords: &'k [&str],
     year: u16,
   ) -> impl Iterator<Item = &'a C> {
-    let searcher = AhoCorasickBuilder::new().build(keywords);
+    let searcher = AhoCorasickBuilder::new().match_kind(ACMatchKind::LeftmostFirst).build(keywords);
     let keywords_len = keywords.len();
     self
       .by_title

--- a/src/imdb/db.rs
+++ b/src/imdb/db.rs
@@ -177,7 +177,7 @@ impl Db {
   /// # Arguments
   /// * `keywords` - Keywords to be searched in the titles
   /// * `query` - Specifies if the query is for movies or series
-  pub(crate) fn by_keywords<'a, 'k: 'a>(
+  pub(crate) fn by_keywords<'a, 'k>(
     &'a self,
     keywords: &'k [&str],
     query: Query,
@@ -193,7 +193,7 @@ impl Db {
   /// * `keywords` - Keywords to be searched in the titles
   /// * `year` - Release date to be queried
   /// * `query` - Specifies if the query is for movies or series
-  pub(crate) fn by_keywords_and_year<'a, 'k: 'a>(
+  pub(crate) fn by_keywords_and_year<'a, 'k>(
     &'a self,
     keywords: &'k [&str],
     year: u16,
@@ -310,14 +310,15 @@ impl<C> DbImpl<C> {
   /// Returns cookies by keywords
   /// # Arguments
   /// * `keywords` - Keywords to be searched in the titles
-  fn cookies_by_keywords<'a, 'k: 'a>(&'a self, keywords: &'k [&str]) -> impl Iterator<Item = &'a C> {
+  fn cookies_by_keywords<'a, 'k>(&'a self, keywords: &'k [&str]) -> impl Iterator<Item = &'a C> {
     let searcher = AhoCorasickBuilder::new().build(keywords);
+    let keywords_len = keywords.len();
     self
       .by_title
       .iter()
       .filter(move |&(title, _)| {
         let matches: FnvHashSet<_> = searcher.find_iter(title).map(|mat| mat.pattern()).collect();
-        matches.len() == keywords.len()
+        matches.len() == keywords_len
       })
       .flat_map(|(_, by_year)| by_year.values())
       .flatten()
@@ -327,21 +328,21 @@ impl<C> DbImpl<C> {
   /// # Arguments
   /// * `keywords` - Keywords to be searched in the titles
   /// * `year` - Release date to be queried
-  fn cookies_by_keywords_and_year<'a, 'k: 'a>(
+  fn cookies_by_keywords_and_year<'a, 'k>(
     &'a self,
     keywords: &'k [&str],
     year: u16,
   ) -> impl Iterator<Item = &'a C> {
     let searcher = AhoCorasickBuilder::new().build(keywords);
+    let keywords_len = keywords.len();
     self
       .by_title
       .iter()
       .filter(move |&(title, _)| {
         let matches: FnvHashSet<_> = searcher.find_iter(title).map(|mat| mat.pattern()).collect();
-        matches.len() == keywords.len()
+        matches.len() == keywords_len
       })
       .filter_map(move |(_, by_year)| by_year.get(&year))
-      // .map(|(_, by_year)| by_year.values())
       .flatten()
   }
 
@@ -397,7 +398,7 @@ impl<C: Into<usize> + Copy> DbImpl<C> {
   /// Returns titles by keywords from the database
   /// # Arguments
   /// * `keywords` - Keywords to be searched in the titles
-  pub(crate) fn by_keywords<'a, 'k: 'a>(&'a self, keywords: &'k [&str]) -> impl Iterator<Item = &'a Title> {
+  pub(crate) fn by_keywords<'a, 'k>(&'a self, keywords: &'k [&str]) -> impl Iterator<Item = &'a Title> {
     self.cookies_by_keywords(keywords).map(|&cookie| &self[cookie])
   }
 
@@ -405,7 +406,7 @@ impl<C: Into<usize> + Copy> DbImpl<C> {
   /// # Arguments
   /// * `keywords` - Keywords to be searched in the titles
   /// * `year` - Release date of the title to be queried
-  pub(crate) fn by_keywords_and_year<'a, 'k: 'a>(
+  pub(crate) fn by_keywords_and_year<'a, 'k>(
     &'a self,
     keywords: &'k [&str],
     year: u16,

--- a/src/imdb/service.rs
+++ b/src/imdb/service.rs
@@ -326,7 +326,7 @@ impl Service {
   /// # Arguments
   /// * `keywords` - List of keywords to search in titles
   /// * `query` - Specifies if movies or series are queried
-  pub fn by_keywords<'a>(&'a self, keywords: &'a [&str], query: Query) -> FnvHashSet<&'a Title> {
+  pub fn by_keywords<'a, 'k>(&'a self, keywords: &'k [&str], query: Query) -> FnvHashSet<&'a Title> {
     self
       .dbs
       .par_iter()
@@ -340,9 +340,9 @@ impl Service {
   /// * `keywords` - List of keywords to search in titles
   /// * `year` - Release year of the title
   /// * `query` - Specifies if movies or series are queried
-  pub fn by_keywords_and_year<'a>(
+  pub fn by_keywords_and_year<'a, 'k>(
     &'a self,
-    keywords: &'a [&str],
+    keywords: &'k [&str],
     year: u16,
     query: Query,
   ) -> FnvHashSet<&'a Title> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -211,7 +211,7 @@ fn create_keywords_set(title: &str) -> Res<Vec<&str>> {
   Ok(keywords)
 }
 
-fn imdb_single_title<'a>(
+fn imdb_title<'a>(
   title: &str,
   imdb: &'a Imdb,
   imdb_url: &Url,
@@ -568,7 +568,7 @@ fn main() {
       let context = Context::new(general_opts, args.general_opts);
       let printer = create_output_printer(&search_opts.output, &context.general_opts);
       let start_time = Instant::now();
-      fail!(context.have_logger, imdb_single_title(&title, &context.service, &context.imdb_url, &search_opts, exact, printer) => {
+      fail!(context.have_logger, imdb_title(&title, &context.service, &context.imdb_url, &search_opts, exact, printer) => {
         context.destroy();
       });
       debug!("IMDB query took {}", format_duration(Instant::now().duration_since(start_time)));

--- a/src/main.rs
+++ b/src/main.rs
@@ -222,12 +222,8 @@ fn imdb_single_title<'a>(
   let mut movies_results = SearchRes::new(search_opts.sort_by_year, search_opts.top);
   let mut series_results = SearchRes::new(search_opts.sort_by_year, search_opts.top);
 
-  let lc_title;
-  let st: String;
-  let search_terms: Option<&str>;
-
-  if let Some((title, year)) = parse_title_and_year(title) {
-    lc_title = title.to_lowercase();
+  let search_terms = if let Some((title, year)) = parse_title_and_year(title) {
+    let lc_title = title.to_lowercase();
     if exact {
       movies_results.extend(imdb.by_title_and_year(&lc_title, year, ImdbQuery::Movies));
       series_results.extend(imdb.by_title_and_year(&lc_title, year, ImdbQuery::Series));
@@ -237,24 +233,22 @@ fn imdb_single_title<'a>(
       series_results.extend(imdb.by_keywords_and_year(&keywords, year, ImdbQuery::Series));
     }
 
-    st = display_title_and_year(title, year);
-    search_terms = Some(&st);
+    Some(display_title_and_year(title, year))
   } else {
-    lc_title = title.to_lowercase();
+    let lc_title = title.to_lowercase();
     if exact {
       movies_results.extend(imdb.by_title(&lc_title, ImdbQuery::Movies));
       series_results.extend(imdb.by_title(&lc_title, ImdbQuery::Series));
-      search_terms = Some(&lc_title);
+      Some(lc_title)
     } else {
       let keywords = create_keywords_set(&lc_title)?;
       movies_results.extend(imdb.by_keywords(&keywords, ImdbQuery::Movies));
       series_results.extend(imdb.by_keywords(&keywords, ImdbQuery::Series));
-      st = display_keywords(&keywords);
-      search_terms = Some(&st);
+      Some(display_keywords(&keywords))
     }
-  }
+  };
 
-  printer.print(Some(movies_results), Some(series_results), imdb_url, search_terms)?;
+  printer.print(Some(movies_results), Some(series_results), imdb_url, search_terms.as_deref())?;
 
   Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -223,53 +223,34 @@ fn imdb_single_title<'a>(
   let mut series_results = SearchRes::new(search_opts.sort_by_year, search_opts.top);
 
   let lc_title;
-  let keywords;
   let st: String;
   let search_terms: Option<&str>;
 
   if let Some((title, year)) = parse_title_and_year(title) {
     lc_title = title.to_lowercase();
-    keywords = if exact {
-      None
-    } else {
-      Some(create_keywords_set(&lc_title)?)
-    };
-
-    if let Some(keywords) = &keywords {
-      movies_results.extend(imdb.by_keywords_and_year(keywords, year, ImdbQuery::Movies));
-    } else {
+    if exact {
       movies_results.extend(imdb.by_title_and_year(&lc_title, year, ImdbQuery::Movies));
-    }
-
-    if let Some(keywords) = &keywords {
-      series_results.extend(imdb.by_keywords_and_year(keywords, year, ImdbQuery::Series));
-    } else {
       series_results.extend(imdb.by_title_and_year(&lc_title, year, ImdbQuery::Series));
+    } else {
+      let keywords = create_keywords_set(&lc_title)?;
+      movies_results.extend(imdb.by_keywords_and_year(&keywords, year, ImdbQuery::Movies));
+      series_results.extend(imdb.by_keywords_and_year(&keywords, year, ImdbQuery::Series));
     }
 
     st = display_title_and_year(title, year);
     search_terms = Some(&st);
   } else {
     lc_title = title.to_lowercase();
-    keywords = if exact {
-      None
-    } else {
-      Some(create_keywords_set(&lc_title)?)
-    };
-
-    if let Some(keywords) = &keywords {
-      movies_results.extend(imdb.by_keywords(keywords, ImdbQuery::Movies));
-    } else {
+    if exact {
       movies_results.extend(imdb.by_title(&lc_title, ImdbQuery::Movies));
-    }
-
-    if let Some(keywords) = &keywords {
-      series_results.extend(imdb.by_keywords(keywords, ImdbQuery::Series));
-      st = display_keywords(keywords);
-      search_terms = Some(&st);
-    } else {
       series_results.extend(imdb.by_title(&lc_title, ImdbQuery::Series));
       search_terms = Some(&lc_title);
+    } else {
+      let keywords = create_keywords_set(&lc_title)?;
+      movies_results.extend(imdb.by_keywords(&keywords, ImdbQuery::Movies));
+      series_results.extend(imdb.by_keywords(&keywords, ImdbQuery::Series));
+      st = display_keywords(&keywords);
+      search_terms = Some(&st);
     }
   }
 


### PR DESCRIPTION
This also fixes an incorrect lifetime which created a dependence of the database and service objects on the keywords passed in, making the API more difficult to use.