### PR TITLE
Split out the binary file loader from the rest of the database layer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 /target
 perf.*
 flamegraph.*

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,14 +2,14 @@
     "redhat.telemetry.enabled": true,
     "gitpod.openInStable.neverPrompt": true,
     "rust-analyzer.checkOnSave.command": "clippy",
-    "rust-analyzer.inlayHints.closureReturnTypeHints": true,
     "rust-analyzer.inlayHints.lifetimeElisionHints": "always",
     "rust-analyzer.inlayHints.lifetimeElisionHints.useParameterNames": false,
-    "rust-analyzer.inlayHints.reborrowHints": true,
-    "rust-analyzer.assist.allowMergingIntoGlobImports": false,
-    "rust-analyzer.assist.importGroup": false,
     "rust-analyzer.cargo.allFeatures": true,
     "rust-analyzer.lens.methodReferences": true,
     "rust-analyzer.lens.references": true,
-    "rust-analyzer.lens.enumVariantReferences": true
+    "rust-analyzer.lens.enumVariantReferences": true,
+    "rust-analyzer.imports.merge.glob": false,
+    "rust-analyzer.imports.group.enable": false,
+    "rust-analyzer.inlayHints.closureReturnTypeHints.enable": true,
+    "rust-analyzer.inlayHints.reborrowHints.enable": true
 }

--- a/lib/examples/query.rs
+++ b/lib/examples/query.rs
@@ -2,6 +2,7 @@
 
 use tvrank::imdb::{Imdb, ImdbQuery};
 use tvrank::utils::result::Res;
+use tvrank::utils::search::SearchString;
 
 fn main() -> Res<()> {
   let cache_dir = tempfile::Builder::new().prefix("tvrank_").tempdir()?;
@@ -12,7 +13,8 @@ fn main() -> Res<()> {
 
   println!("Matches for {} and {:?}:", title, year);
 
-  for title in imdb.by_title_and_year(title, year, ImdbQuery::Movies) {
+  let search_string = SearchString::try_from(title)?;
+  for title in imdb.by_title_and_year(&search_string, year, ImdbQuery::Movies) {
     let id = title.title_id();
 
     println!("ID: {}", id);

--- a/lib/src/imdb/db_binary.rs
+++ b/lib/src/imdb/db_binary.rs
@@ -1,0 +1,253 @@
+use super::db::Db;
+use crate::imdb::title::Title;
+use crate::imdb::title_id::TitleId;
+use crate::{imdb::db::Query, utils::search::SearchString};
+use log::debug;
+use parking_lot::{const_mutex, Mutex};
+use rayon::prelude::*;
+
+pub struct ServiceDbFromBinary {
+  dbs: Vec<Db>,
+}
+
+impl ServiceDbFromBinary {
+  /// Load titles from the given binary data.
+  ///
+  /// Loads titles from the provided binary content buffers (`movies_data` and
+  /// `series_data`) into one of the thread-handled databases.
+  ///
+  /// # Arguments
+  ///
+  /// * `movies_data` - Binary movies data.
+  /// * `series_data` - Binary series data.
+  pub(crate) fn new(mut movies_data: &'static [u8], mut series_data: &'static [u8]) -> Self {
+    let nthreads = rayon::current_num_threads();
+    let dbs = const_mutex(Vec::with_capacity(nthreads));
+    let movies_cursor: Mutex<&mut &'static [u8]> = const_mutex(&mut movies_data);
+    let series_cursor: Mutex<&mut &'static [u8]> = const_mutex(&mut series_data);
+
+    rayon::scope(|scope| {
+      for _ in 0..nthreads {
+        let dbs = &dbs;
+        let movies_cursor = &movies_cursor;
+        let series_cursor = &series_cursor;
+
+        scope.spawn(move |_| {
+          let mut db = Db::with_capacities(1_900_000 / nthreads, 270_000 / nthreads);
+          let mut titles = Vec::with_capacity(100);
+          Self::titles_from_binary::<true>(movies_cursor, &mut titles, &mut db);
+          Self::titles_from_binary::<false>(series_cursor, &mut titles, &mut db);
+          dbs.lock().push(db);
+        });
+      }
+    });
+
+    Self { dbs: dbs.into_inner() }
+  }
+
+  /// Loads titles from the provided binary content buffers into the thread-handled
+  /// databases.
+  ///
+  /// # Arguments
+  ///
+  /// * `cursor` - Cursor at the binary to read the titles from.
+  /// * `titles` - Vector to store the titles temporarily before writing to the database.
+  /// * `db` - Database to store movies or series.
+  fn titles_from_binary<const IS_MOVIE: bool>(
+    cursor: &Mutex<&mut &'static [u8]>,
+    titles: &mut Vec<Title<'static>>,
+    db: &mut Db,
+  ) {
+    loop {
+      let mut cursor_guard = cursor.lock();
+
+      if (*cursor_guard).is_empty() {
+        break;
+      }
+
+      for _ in 0..100 {
+        if (*cursor_guard).is_empty() {
+          break;
+        }
+
+        let title = match Title::from_binary(&mut cursor_guard) {
+          Ok(title) => title,
+          Err(e) => panic!("Error parsing title: {}", e),
+        };
+
+        titles.push(title);
+      }
+
+      drop(cursor_guard);
+
+      for &title in titles.iter() {
+        if IS_MOVIE {
+          db.store_movie(title);
+        } else {
+          db.store_series(title);
+        }
+      }
+
+      titles.clear();
+    }
+  }
+
+  /// Calculate the total number of movies and series entries.
+  ///
+  /// # Return
+  ///
+  /// Returns a tuple containing two numbers, the first one is the number of movies and
+  /// the second on the number of series contained in the database.
+  pub(crate) fn n_entries(&self) -> (usize, usize) {
+    let mut total_movies = 0;
+    let mut total_series = 0;
+
+    for (i, db) in self.dbs.iter().enumerate() {
+      let movies = db.n_movies();
+      let series = db.n_series();
+      let entries = db.n_entries();
+
+      total_movies += movies;
+      total_series += series;
+
+      debug!("IMDB database (thread {i}) contains {movies} movies and {series} series ({entries} entries)");
+    }
+
+    (total_movies, total_series)
+  }
+
+  pub(crate) fn by_id(&self, id: &TitleId, query: Query) -> Option<&Title> {
+    let res = self
+      .dbs
+      .par_iter()
+      .map(|db| db.by_id(id, query))
+      .filter(|res| res.is_some())
+      .flatten()
+      .collect::<Vec<_>>();
+
+    if res.is_empty() {
+      None
+    } else {
+      Some(unsafe { res.get_unchecked(0) })
+    }
+  }
+
+  pub(crate) fn by_title(&self, title: &SearchString, query: Query) -> Vec<&Title> {
+    self
+      .dbs
+      .par_iter()
+      .flat_map(|db| db.by_title(title, query).collect::<Vec<_>>())
+      .collect()
+  }
+
+  pub(crate) fn by_title_and_year(&self, title: &SearchString, year: u16, query: Query) -> Vec<&Title> {
+    self
+      .dbs
+      .par_iter()
+      .flat_map(|db| db.by_title_and_year(title, year, query).collect::<Vec<_>>())
+      .collect()
+  }
+
+  pub(crate) fn by_keywords<'a, 'k>(&'a self, keywords: &'k [SearchString], query: Query) -> Vec<&'a Title> {
+    self
+      .dbs
+      .par_iter()
+      .flat_map(|db| db.by_keywords(keywords, query).collect::<Vec<_>>())
+      .collect()
+  }
+
+  pub(crate) fn by_keywords_and_year<'a, 'k>(
+    &'a self,
+    keywords: &'k [SearchString],
+    year: u16,
+    query: Query,
+  ) -> Vec<&'a Title> {
+    self
+      .dbs
+      .par_iter()
+      .flat_map(|db| db.by_keywords_and_year(keywords, year, query).collect::<Vec<_>>())
+      .collect()
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use crate::imdb::db::Query;
+  use crate::imdb::db::ServiceDb;
+  use crate::imdb::db_binary::ServiceDbFromBinary;
+  use crate::imdb::testdata::{make_basics_reader, make_ratings_reader};
+  use crate::imdb::title_id::TitleId;
+  use crate::utils::search::SearchString;
+
+  fn make_service_db_from_binary() -> ServiceDbFromBinary {
+    let basics_reader = make_basics_reader();
+    let ratings_reader = make_ratings_reader();
+
+    let mut movies_storage = Vec::new();
+    let mut series_storage = Vec::new();
+    ServiceDb::import(ratings_reader, basics_reader, &mut movies_storage, &mut series_storage).unwrap();
+
+    let movies_storage = Box::leak(movies_storage.into_boxed_slice());
+    let series_storage = Box::leak(series_storage.into_boxed_slice());
+    ServiceDbFromBinary::new(movies_storage, series_storage)
+  }
+
+  #[test]
+  fn test_n_entries() {
+    let service_db = make_service_db_from_binary();
+    assert_eq!(service_db.n_entries(), (11, 0));
+  }
+
+  #[test]
+  fn test_by_id() {
+    let service_db = make_service_db_from_binary();
+    let title = service_db
+      .by_id(&TitleId::try_from("tt0000007").unwrap(), Query::Movies)
+      .unwrap();
+    assert_eq!(title.title_id(), &TitleId::try_from("tt0000007").unwrap());
+    assert_eq!(title.primary_title(), "Corbett and Courtney Before the Kinetograph");
+  }
+
+  #[test]
+  fn test_by_title() {
+    let service_db = make_service_db_from_binary();
+    let title = SearchString::try_from("Corbett and Courtney Before the Kinetograph").unwrap();
+    let titles = service_db.by_title(&title, Query::Movies);
+    assert_eq!(titles.len(), 1);
+    let title = titles[0];
+    assert_eq!(title.title_id(), &TitleId::try_from("tt0000007").unwrap());
+    assert_eq!(title.primary_title(), "Corbett and Courtney Before the Kinetograph");
+  }
+
+  #[test]
+  fn test_by_title_and_year() {
+    let service_db = make_service_db_from_binary();
+    let title = SearchString::try_from("Corbett and Courtney Before the Kinetograph").unwrap();
+    let titles = service_db.by_title_and_year(&title, 1894, Query::Movies);
+    assert_eq!(titles.len(), 1);
+    let title = titles[0];
+    assert_eq!(title.title_id(), &TitleId::try_from("tt0000007").unwrap());
+    assert_eq!(title.primary_title(), "Corbett and Courtney Before the Kinetograph");
+  }
+
+  #[test]
+  fn test_by_keywords() {
+    let service_db = make_service_db_from_binary();
+    let titles = service_db.by_keywords(&[SearchString::try_from("Corbett").unwrap()], Query::Movies);
+    assert_eq!(titles.len(), 1);
+    let title = titles[0];
+    assert_eq!(title.title_id(), &TitleId::try_from("tt0000007").unwrap());
+    assert_eq!(title.primary_title(), "Corbett and Courtney Before the Kinetograph");
+  }
+
+  #[test]
+  fn test_by_keywords_and_year() {
+    let service_db = make_service_db_from_binary();
+    let titles =
+      service_db.by_keywords_and_year(&[SearchString::try_from("Kineto").unwrap()], 1915, Query::Movies);
+    assert_eq!(titles.len(), 1);
+    let title = titles[0];
+    assert_eq!(title.title_id(), &TitleId::try_from("tt0212278").unwrap());
+    assert_eq!(title.primary_title(), "Kineto's Side-Splitters No. 1");
+  }
+}

--- a/lib/src/imdb/mod.rs
+++ b/lib/src/imdb/mod.rs
@@ -4,6 +4,7 @@
 //! Module for TVrank to use the IMDB dataset (TSV dumps) as a source.
 
 mod db;
+mod db_binary;
 mod error;
 mod genre;
 mod ratings;
@@ -13,6 +14,9 @@ mod title_header;
 mod title_id;
 mod title_type;
 mod tokens;
+
+#[cfg(test)]
+mod testdata;
 
 pub use db::Query as ImdbQuery;
 pub use error::Err as ImdbErr;

--- a/lib/src/imdb/testdata.rs
+++ b/lib/src/imdb/testdata.rs
@@ -1,0 +1,36 @@
+use indoc::indoc;
+use std::io::BufRead;
+
+pub(crate) fn make_basics_reader() -> impl BufRead {
+  indoc! {"
+      tconst\ttitleType\tprimaryTitle\toriginalTitle\tisAdult\tstartYear\tendYear\truntimeMinutes\tgenres
+      tt0000001\tshort\tCarmencita\tCarmencita\t0\t1894\t\\N\t1\tDocumentary,Short
+      tt0000002\tshort\tLe clown et ses chiens\tLe clown et ses chiens\t0\t1892\t\\N\t5\tAnimation,Short
+      tt0000003\tshort\tPauvre Pierrot\tPauvre Pierrot\t0\t1892\t\\N\t4\tAnimation,Comedy,Romance
+      tt0000004\tshort\tUn bon bock\tUn bon bock\t0\t1892\t\\N\t12\tAnimation,Short
+      tt0000005\tshort\tBlacksmith Scene\tBlacksmith Scene\t0\t1893\t\\N\t1\tComedy,Short
+      tt0000006\tshort\tChinese Opium Den\tChinese Opium Den\t0\t1894\t\\N\t1\tShort
+      tt0000007\tshort\tCorbett and Courtney Before the Kinetograph\tCorbett and Courtney Before the Kinetograph\t0\t1894\t\\N\t1\tShort,Sport
+      tt0000008\tshort\tEdison Kinetoscopic Record of a Sneeze\tEdison Kinetoscopic Record of a Sneeze\t0\t1894\t\\N\t1\tDocumentary,Short
+      tt0000009\tshort\tMiss Jerry\tMiss Jerry\t0\t1894\t\\N\t40\tRomance,Short
+      tt0000010\tshort\tLeaving the Factory\tLa sortie de l'usine Lumière à Lyon\t0\t1895\t\\N\t1\tDocumentary,Short
+      tt0212278\tshort\tKineto's Side-Splitters No. 1\tKineto's Side-Splitters No. 1\t0\t1915\t\\N\t\\N\tShort
+    "}.as_bytes()
+}
+
+pub(crate) fn make_ratings_reader() -> impl BufRead {
+  indoc! {"
+      tconst\taverageRating\tnumVotes
+      tt0000001\t5.7\t1845
+      tt0000002\t6.0\t236
+      tt0000003\t6.5\t1603
+      tt0000004\t6.0\t153
+      tt0000005\t6.2\t2424
+      tt0000006\t5.2\t158
+      tt0000007\t5.4\t758
+      tt0000008\t5.5\t1988
+      tt0000009\t5.9\t191
+      tt0000010\t6.9\t6636
+    "}
+  .as_bytes()
+}

--- a/lib/src/imdb/title.rs
+++ b/lib/src/imdb/title.rs
@@ -217,20 +217,20 @@ impl<'storage> Title<'storage> {
   /// # Arguments
   /// `writer` - Writer to write the title to
   pub(crate) fn write_binary<W: Write>(&self, writer: &mut W) -> Res<()> {
-    let _ = writer.write_all(&self.header.to_le_bytes())?;
+    writer.write_all(&self.header.to_le_bytes())?;
 
     let title_id = self.title_id.as_bytes();
-    let _ = writer.write_all(&(title_id.len() as u8).to_le_bytes());
-    let _ = writer.write_all(title_id)?;
+    writer.write_all(&(title_id.len() as u8).to_le_bytes())?;
+    writer.write_all(title_id)?;
 
     let primary_title = self.primary_title.as_bytes();
-    let _ = writer.write_all(&(primary_title.len() as u16).to_le_bytes());
-    let _ = writer.write_all(primary_title)?;
+    writer.write_all(&(primary_title.len() as u16).to_le_bytes())?;
+    writer.write_all(primary_title)?;
 
     if let Some(original_title) = self.original_title {
       let original_title = original_title.as_bytes();
-      let _ = writer.write_all(&(original_title.len() as u16).to_le_bytes())?;
-      let _ = writer.write_all(original_title)?;
+      writer.write_all(&(original_title.len() as u16).to_le_bytes())?;
+      writer.write_all(original_title)?;
     }
 
     Ok(())

--- a/lib/src/imdb/title_header.rs
+++ b/lib/src/imdb/title_header.rs
@@ -73,16 +73,8 @@ impl TitleHeader {
     genres: Genres,
   ) -> Self {
     let version = 0;
-    let has_original_title = if has_original_title {
-      1
-    } else {
-      0
-    };
-    let is_adult = if is_adult {
-      1
-    } else {
-      0
-    };
+    let has_original_title = u128::from(has_original_title);
+    let is_adult = u128::from(is_adult);
 
     let runtime = if let Some(runtime) = runtime_minutes {
       u128::from(runtime)

--- a/lib/src/utils/mod.rs
+++ b/lib/src/utils/mod.rs
@@ -5,4 +5,5 @@
 
 pub mod io;
 pub mod result;
+pub mod search;
 pub mod tokens;

--- a/lib/src/utils/search.rs
+++ b/lib/src/utils/search.rs
@@ -1,0 +1,76 @@
+//! A string type used to ensure that search keywords are lowercase and non-empty.
+
+use derive_more::Display;
+use std::error::Error;
+
+/// Error type for search string construction.
+#[derive(Debug, Display)]
+#[display(fmt = "{}")]
+pub enum SearchStringErr {
+  /// Thrown if a search string is empty.
+  #[display(fmt = "Search title or keyword is empty")]
+  IsEmpty,
+}
+
+impl Error for SearchStringErr {}
+
+/// A string type used to ensure that search keywords are lowercase and non-empty.
+pub struct SearchString {
+  contents: String,
+}
+
+impl SearchString {
+  /// Return the search string as a string slice.
+  pub fn as_str(&self) -> &str {
+    &self.contents
+  }
+}
+
+impl AsRef<[u8]> for SearchString {
+  fn as_ref(&self) -> &[u8] {
+    self.contents.as_bytes()
+  }
+}
+
+impl From<SearchString> for String {
+  fn from(searchstring: SearchString) -> Self {
+    searchstring.contents
+  }
+}
+
+impl TryFrom<&str> for SearchString {
+  type Error = SearchStringErr;
+
+  fn try_from(value: &str) -> Result<Self, Self::Error> {
+    if value.is_empty() {
+      return Err(SearchStringErr::IsEmpty);
+    }
+
+    Ok(Self { contents: value.to_lowercase() })
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  #[should_panic]
+  fn empty() {
+    let _ = SearchString::try_from("").unwrap();
+  }
+
+  #[test]
+  fn lowercase() {
+    let value = "hello";
+    let search_string = SearchString::try_from(value).unwrap();
+    assert_eq!(value, search_string.as_str());
+  }
+
+  #[test]
+  fn non_lowercase() {
+    let value = "HeLLo";
+    let search_string = SearchString::try_from(value).unwrap();
+    assert_eq!(value.to_lowercase(), search_string.as_str());
+  }
+}


### PR DESCRIPTION
- Split the database layer into `ServiceDb` and `ServiceDbFromBinary`, the former being a query layer for different database backends, and the latter one implementation of such backends: namely the custom binary format loader.

- Introduce a `SearchString` structure that ensures that any string used for searching - be it a title or a keyword - holds certain properties (like always being lowercase and non-empty). `SearchString`s are used throughout the public and private APIs.

Co-authored-by: @koushik-ms
Co-authored-by: @HenningHolmDE
Co-authored-by: @VAISHALI-DHANOA
Co-authored-by: @Olsi-B