### PR TITLE
Fix Github CI deprecation warnings about `::set-output`

### DIFF
--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -20,12 +20,13 @@ jobs:
       matrix: ${{steps.set-matrix.outputs.matrix}}
     steps:
       - id: set-matrix
+        name: Generate build matrix
         shell: python
         # env:
         #   ENABLE_PRODUCTION: ${{startsWith(github.ref, 'refs/tags/')}}
         run: |
           import json
-          # import os
+          import os
 
           matrix = {
             'os': [
@@ -69,16 +70,11 @@ jobs:
             ]
           }
 
-          # if os.getenv('ENABLE_PRODUCTION', default='false') == 'true':
-          #   matrix['build-config'].append({
-          #     'id': 'production',
-          #     'args': '--profile production',
-          #   })
-
           matrix_json = json.dumps(matrix)
-          # print(f'::set-output name=matrix::{matrix_json}')
-          with open('$GITHUB_OUTPUT', 'w', encoding='ascii') as out:
-              out.write(matrix_json)
+          env_file = os.getenv('GITHUB_OUTPUT')
+          if env_file is not None:
+            with open(env_file, 'a', encoding='utf8') as out:
+                print(f'matrix={matrix_json}', file=out)
 
   code-formatting:
     name: Code formatting

--- a/README.md
+++ b/README.md
@@ -3,8 +3,7 @@
 [![License](https://img.shields.io/github/license/fredmorcos/tvrank?style=for-the-badge)](https://github.com/fredmorcos/tvrank/blob/main/LICENSE)
 [![Release (latest SemVer)](https://img.shields.io/github/v/release/fredmorcos/tvrank?sort=semver&style=for-the-badge)](https://github.com/fredmorcos/tvrank/releases)
 [![Crates.io](https://img.shields.io/crates/v/tvrank?style=for-the-badge)](https://crates.io/crates/tvrank)
-[![Release](https://img.shields.io/github/workflow/status/fredmorcos/tvrank/Release?label=Release&style=for-the-badge)](https://github.com/fredmorcos/tvrank/releases)
-[![CI](https://img.shields.io/github/workflow/status/fredmorcos/tvrank/CI?label=Master&style=for-the-badge)](https://github.com/fredmorcos/tvrank/actions)
+[![CI](https://img.shields.io/github/actions/workflow/status/fredmorcos/tvrank/build-test-publish.yml?label=Main&style=for-the-badge)](https://github.com/fredmorcos/tvrank/actions)
 </br>
 [![docs.rs](https://img.shields.io/docsrs/tvrank?style=for-the-badge)](https://docs.rs/tvrank/0.8.4/tvrank/)
 [![Github Open Issues](https://img.shields.io/github/issues-raw/fredmorcos/tvrank?style=for-the-badge)](https://github.com/fredmorcos/tvrank/issues)


### PR DESCRIPTION
What the title says, stop using `::set-output` and replace it with environment files in accordance with [this](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/).

The [first commit for this](https://github.com/fredmorcos/tvrank/commit/9f7e12efd80bcb6ffd133e8012995287b5d75805) was mistakenly pushed directly to main which broke CI.