### PR TITLE
Simplify progress closure

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,7 +308,7 @@ and is a `FnMut` to be able to e.g. mutate a progress bar object.
 
 ```rust
 let cache_dir = tempfile::Builder::new().prefix("tvrank_").tempdir()?;
-let imdb = Imdb::new(cache_dir.path(), false, &mut |_| {})?;
+let imdb = Imdb::new(cache_dir.path(), false, |_, _| {})?;
 ```
 
 Afterwards, one can query the database using either `imdb.by_id(...)`,

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -524,7 +524,7 @@ fn create_output_printer(output_format: &OutputFormat, general_opts: &GeneralOpt
 fn create_imdb_service(app_cache_dir: &Path, force_update: bool) -> Res<Imdb> {
   let start_time = Instant::now();
   let progress_bar: RefCell<Option<ProgressBar>> = RefCell::new(None);
-  let imdb = Imdb::new(app_cache_dir, force_update, &|content_len: Option<u64>, delta| {
+  let imdb = Imdb::new(app_cache_dir, force_update, |content_len: Option<u64>, delta| {
     let mut progress_bar_mut = progress_bar.borrow_mut();
     match &*progress_bar_mut {
       Some(bar) => bar.inc(delta),

--- a/lib/examples/query.rs
+++ b/lib/examples/query.rs
@@ -6,7 +6,7 @@ use tvrank::utils::search::SearchString;
 
 fn main() -> Res<()> {
   let cache_dir = tempfile::Builder::new().prefix("tvrank_").tempdir()?;
-  let imdb = Imdb::new(cache_dir.path(), false, &|_, _| {})?;
+  let imdb = Imdb::new(cache_dir.path(), false, |_, _| {})?;
 
   let title = "city of god";
   let year = 2002;

--- a/lib/src/utils/io.rs
+++ b/lib/src/utils/io.rs
@@ -6,27 +6,28 @@ use std::io::Read;
 
 /// An object that offers a callback-based mechanism on `std::io::Read` objects.
 ///
-/// This object maintains a closure and the object (read stream) `R`. It forwards
-/// `std::io::Read::read` calls to `R` but also calls the closure with how many bytes
-/// were read from `R`. This can be used as a progress reporting mechanism.
-pub struct Progress<'a, R> {
+/// This object maintains a closure of type `F` and the object (read stream) of type
+/// `R`. It forwards `std::io::Read::read` calls to `R` but also calls the closure `F`
+/// with how many bytes were read from `R`. This can be used as a progress reporting
+/// mechanism.
+pub struct Progress<R, F: Fn(Option<u64>, u64)> {
   inner: R,
-  progress_fn: &'a dyn Fn(Option<u64>, u64),
+  progress_fn: F,
 }
 
-impl<'a, R: Read> Progress<'a, R> {
+impl<R: Read, F: Fn(Option<u64>, u64)> Progress<R, F> {
   /// Construct a new `Progress` object.
   ///
   /// # Arguments
   ///
   /// * `inner` - The inner (read stream) object.
   /// * `progress_fn` - The callback closure to keep track of read progress.
-  pub fn new(inner: R, progress_fn: &'a dyn Fn(Option<u64>, u64)) -> Self {
+  pub fn new(inner: R, progress_fn: F) -> Self {
     Self { inner, progress_fn }
   }
 }
 
-impl<'a, R: Read> Read for Progress<'a, R> {
+impl<R: Read, F: Fn(Option<u64>, u64)> Read for Progress<R, F> {
   fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
     let bytes = self.inner.read(buf)?;
     (self.progress_fn)(None, bytes as u64);


### PR DESCRIPTION
The closure type passed to the library to report download progress is now moved instead of passed by reference. This simplifies quite a few things including the removal of explicit lifetimes.

This also simplifies the type of the downloader, use `impl BufRead` instead of naming the full concrete type.