### PR TITLE
Rename to `ProgressPipe` and simplify the closure

### DIFF
--- a/lib/src/imdb/service.rs
+++ b/lib/src/imdb/service.rs
@@ -10,7 +10,7 @@ use crate::imdb::db_binary::ServiceDbFromBinary;
 use crate::imdb::title::Title;
 use crate::imdb::title_id::TitleId;
 use crate::imdb::tsv_import::tsv_import;
-use crate::utils::io::Progress;
+use crate::utils::io::ProgressPipe;
 use crate::utils::result::Res;
 use crate::utils::search::SearchString;
 
@@ -122,7 +122,7 @@ impl Service {
   /// * `resp` - Response returned for the GET request
   /// * `progress_fn` - Function to keep track of the download progress
   fn create_downloader(resp: Response, progress_fn: impl Fn(Option<u64>, u64)) -> impl BufRead {
-    let progress = Progress::new(resp, progress_fn);
+    let progress = ProgressPipe::new(resp, progress_fn);
     let reader = BufReader::new(progress);
     let decoder = GzDecoder::new(reader);
     BufReader::new(decoder)

--- a/lib/src/imdb/service.rs
+++ b/lib/src/imdb/service.rs
@@ -121,7 +121,7 @@ impl Service {
   /// # Arguments
   /// * `resp` - Response returned for the GET request
   /// * `progress_fn` - Function to keep track of the download progress
-  fn create_downloader(resp: Response, progress_fn: impl Fn(Option<u64>, u64)) -> impl BufRead {
+  fn create_downloader(resp: Response, progress_fn: impl Fn(u64)) -> impl BufRead {
     let progress = ProgressPipe::new(resp, progress_fn);
     let reader = BufReader::new(progress);
     let decoder = GzDecoder::new(reader);
@@ -168,8 +168,8 @@ impl Service {
         }
       }
 
-      let basics_downloader = Self::create_downloader(basics_resp, &progress_fn);
-      let ratings_downloader = Self::create_downloader(ratings_resp, &progress_fn);
+      let basics_downloader = Self::create_downloader(basics_resp, |bytes| progress_fn(None, bytes));
+      let ratings_downloader = Self::create_downloader(ratings_resp, |bytes| progress_fn(None, bytes));
 
       let movies_db_file = File::create(movies_db_filename)?;
       let movies_db_writer = BufWriter::new(movies_db_file);

--- a/lib/src/utils/io.rs
+++ b/lib/src/utils/io.rs
@@ -6,30 +6,35 @@ use std::io::Read;
 
 /// An object that offers a callback-based mechanism on `std::io::Read` objects.
 ///
-/// This object maintains a closure of type `F` and the object (read stream) of type
-/// `R`. It forwards `std::io::Read::read` calls to `R` but also calls the closure `F`
-/// with how many bytes were read from `R`. This can be used as a progress reporting
+/// This object maintains a closure of type `F` and the source object (read stream) of
+/// type `R`. It forwards `std::io::Read::read` calls to `R` but also calls the closure
+/// `F` with how many bytes were read from `R`. This can be used as a progress reporting
 /// mechanism.
-pub struct Progress<R, F: Fn(Option<u64>, u64)> {
-  inner: R,
+///
+/// `ProgressPipe` reads from a `source` object of type `R` whenever it is read from using
+/// its implementation of `std::io::Read`, but instead of immediately forwarding what is
+/// read, it first calls the closure of type `F` with the number of bytes that were
+/// consumed from the source object.
+pub struct ProgressPipe<R, F: Fn(Option<u64>, u64)> {
+  source: R,
   progress_fn: F,
 }
 
-impl<R: Read, F: Fn(Option<u64>, u64)> Progress<R, F> {
+impl<R: Read, F: Fn(Option<u64>, u64)> ProgressPipe<R, F> {
   /// Construct a new `Progress` object.
   ///
   /// # Arguments
   ///
-  /// * `inner` - The inner (read stream) object.
+  /// * `source` - The source (read stream) object.
   /// * `progress_fn` - The callback closure to keep track of read progress.
-  pub fn new(inner: R, progress_fn: F) -> Self {
-    Self { inner, progress_fn }
+  pub fn new(source: R, progress_fn: F) -> Self {
+    Self { source, progress_fn }
   }
 }
 
-impl<R: Read, F: Fn(Option<u64>, u64)> Read for Progress<R, F> {
-  fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
-    let bytes = self.inner.read(buf)?;
+impl<R: Read, F: Fn(Option<u64>, u64)> Read for ProgressPipe<R, F> {
+  fn read(&mut self, destination: &mut [u8]) -> std::io::Result<usize> {
+    let bytes = self.source.read(destination)?;
     (self.progress_fn)(None, bytes as u64);
     Ok(bytes)
   }

--- a/lib/src/utils/io.rs
+++ b/lib/src/utils/io.rs
@@ -15,12 +15,12 @@ use std::io::Read;
 /// its implementation of `std::io::Read`, but instead of immediately forwarding what is
 /// read, it first calls the closure of type `F` with the number of bytes that were
 /// consumed from the source object.
-pub struct ProgressPipe<R, F: Fn(Option<u64>, u64)> {
+pub struct ProgressPipe<R, F: Fn(u64)> {
   source: R,
   progress_fn: F,
 }
 
-impl<R: Read, F: Fn(Option<u64>, u64)> ProgressPipe<R, F> {
+impl<R: Read, F: Fn(u64)> ProgressPipe<R, F> {
   /// Construct a new `Progress` object.
   ///
   /// # Arguments
@@ -32,10 +32,10 @@ impl<R: Read, F: Fn(Option<u64>, u64)> ProgressPipe<R, F> {
   }
 }
 
-impl<R: Read, F: Fn(Option<u64>, u64)> Read for ProgressPipe<R, F> {
+impl<R: Read, F: Fn(u64)> Read for ProgressPipe<R, F> {
   fn read(&mut self, destination: &mut [u8]) -> std::io::Result<usize> {
     let bytes = self.source.read(destination)?;
-    (self.progress_fn)(None, bytes as u64);
+    (self.progress_fn)(bytes as u64);
     Ok(bytes)
   }
 }


### PR DESCRIPTION
What the title says, just a refactoring.