### PR TITLE
Shorten the `Res<()>` type to `Res` by making `T=()` the default

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -251,7 +251,7 @@ fn imdb_title<'a>(
   search_opts: &SearchOpts,
   exact: bool,
   printer: Box<dyn Printer>,
-) -> Res<()> {
+) -> Res {
   let mut movies_results = SearchRes::new(search_opts.sort_by_year, search_opts.top);
   let mut series_results = SearchRes::new(search_opts.sort_by_year, search_opts.top);
 
@@ -290,7 +290,7 @@ fn imdb_movies_dir(
   imdb_url: &Url,
   search_opts: &SearchOpts,
   printer: Box<dyn Printer>,
-) -> Res<()> {
+) -> Res {
   let mut at_least_one = false;
   let mut at_least_one_matched = false;
   let mut results = SearchRes::new(search_opts.sort_by_year, search_opts.top);
@@ -371,7 +371,7 @@ fn imdb_movies_dir(
   Ok(())
 }
 
-fn imdb_mark(dir: &Path, id: &str, imdb: &Imdb, force: bool) -> Res<()> {
+fn imdb_mark(dir: &Path, id: &str, imdb: &Imdb, force: bool) -> Res {
   // DONE 1.   Check if the directory exist.
   // DONE 2.   If not, fail.
   // DONE 3.   Check if tvrank.json exists in there.
@@ -419,7 +419,7 @@ fn imdb_series_dir(
   imdb_url: &Url,
   search_opts: &SearchOpts,
   printer: Box<dyn Printer>,
-) -> Res<()> {
+) -> Res {
   let mut at_least_one = false;
   let mut at_least_one_matched = false;
   let mut results = SearchRes::new(search_opts.sort_by_year, search_opts.top);

--- a/cli/src/print.rs
+++ b/cli/src/print.rs
@@ -40,7 +40,7 @@ pub trait Printer {
     series: Option<SearchRes>,
     imdb_url: &Url,
     search_terms: Option<&str>,
-  ) -> Res<()>;
+  ) -> Res;
 }
 
 pub struct JsonPrinter;
@@ -63,7 +63,7 @@ impl Printer for JsonPrinter {
     mut series: Option<SearchRes>,
     _imdb_url: &Url,
     _search_terms: Option<&str>,
-  ) -> Res<()> {
+  ) -> Res {
     println!(
       "{}",
       serde_json::to_string_pretty(&OutputWrapper::new(
@@ -95,7 +95,7 @@ impl Printer for YamlPrinter {
     mut series: Option<SearchRes>,
     _imdb_url: &Url,
     _search_terms: Option<&str>,
-  ) -> Res<()> {
+  ) -> Res {
     println!(
       "{}",
       serde_yaml::to_string(&OutputWrapper::new(
@@ -123,7 +123,7 @@ impl Printer for TablePrinter {
     series: Option<SearchRes>,
     imdb_url: &Url,
     search_terms: Option<&str>,
-  ) -> Res<()> {
+  ) -> Res {
     if let Some(movies) = movies {
       self.print_results(movies, imdb_url, ImdbQuery::Movies, search_terms)?;
     }
@@ -147,7 +147,7 @@ impl TablePrinter {
     imdb_url: &Url,
     query: ImdbQuery,
     search_terms: Option<&str>,
-  ) -> Res<()> {
+  ) -> Res {
     if results.is_empty() {
       if let Some(search_terms) = search_terms {
         eprintln!("No {} matches found for `{search_terms}`", query);

--- a/lib/examples/query.rs
+++ b/lib/examples/query.rs
@@ -4,7 +4,7 @@ use tvrank::imdb::{Imdb, ImdbQuery};
 use tvrank::utils::result::Res;
 use tvrank::utils::search::SearchString;
 
-fn main() -> Res<()> {
+fn main() -> Res {
   let cache_dir = tempfile::Builder::new().prefix("tvrank_").tempdir()?;
   let imdb = Imdb::new(cache_dir.path(), false, |_, _| {})?;
 

--- a/lib/src/imdb/service.rs
+++ b/lib/src/imdb/service.rs
@@ -140,7 +140,7 @@ impl Service {
     series_db_filename: &Path,
     force_db_update: bool,
     progress_fn: impl Fn(Option<u64>, u64),
-  ) -> Res<()> {
+  ) -> Res {
     let needs_update = {
       let movies_db_file = Self::file_exists(movies_db_filename)?;
       let series_db_file = Self::file_exists(series_db_filename)?;

--- a/lib/src/imdb/title.rs
+++ b/lib/src/imdb/title.rs
@@ -216,7 +216,7 @@ impl<'storage> Title<'storage> {
   /// Writes the title as binary
   /// # Arguments
   /// `writer` - Writer to write the title to
-  pub(crate) fn write_binary<W: Write>(&self, writer: &mut W) -> Res<()> {
+  pub(crate) fn write_binary<W: Write>(&self, writer: &mut W) -> Res {
     writer.write_all(&self.header.to_le_bytes())?;
 
     let title_id = self.title_id.as_bytes();

--- a/lib/src/imdb/tsv_import.rs
+++ b/lib/src/imdb/tsv_import.rs
@@ -24,7 +24,7 @@ pub(crate) fn tsv_import<R1: BufRead, R2: BufRead, W1: Write, W2: Write>(
   mut basics_reader: R2,
   mut movies_db_writer: W1,
   mut series_db_writer: W2,
-) -> Res<()> {
+) -> Res {
   let ratings = Ratings::from_tsv(ratings_reader)?;
 
   let mut line = String::new();

--- a/lib/src/utils/result.rs
+++ b/lib/src/utils/result.rs
@@ -5,4 +5,4 @@
 use std::error::Error;
 
 /// A shorthand type for library functions that may return errors.
-pub type Res<T> = Result<T, Box<dyn Error>>;
+pub type Res<T = ()> = Result<T, Box<dyn Error>>;


### PR DESCRIPTION
We use this `type Res<T> = Result<T, Box<dyn Error>>` to alias the result type (`Result<T, Box<dyn Error>>`) which is used everywhere to a shorter name (`Res<T>`) since the error type is always a `Box<dyn Error>`.

I don't like it but it's shorter, and it should really be going away.