### PR TITLE
Organize helper functions from the `service` module

### DIFF
--- a/lib/src/imdb/genre.rs
+++ b/lib/src/imdb/genre.rs
@@ -32,15 +32,15 @@ pub enum Genre {
   Family = 9,
   /// Fantasy
   Fantasy = 10,
+  /// FilmNoir
   #[display(fmt = "Film-Noir")]
   #[enumeration(rename = "Film-Noir")]
   #[serde(rename(serialize = "Film-Noir"))]
-  /// FilmNoir
   FilmNoir = 11,
+  /// GameShow
   #[display(fmt = "Game-Show")]
   #[enumeration(rename = "Game-Show")]
   #[serde(rename(serialize = "Game-Show"))]
-  /// GameShow
   GameShow = 12,
   /// History
   History = 13,
@@ -54,26 +54,26 @@ pub enum Genre {
   Mystery = 17,
   /// News
   News = 18,
+  /// RealityTv
   #[display(fmt = "Reality-TV")]
   #[enumeration(rename = "Reality-TV")]
   #[serde(rename(serialize = "Reality-TV"))]
-  /// RealityTv
   RealityTv = 19,
   /// Romance
   Romance = 20,
+  /// SciFi
   #[display(fmt = "Sci-Fi")]
   #[enumeration(rename = "Sci-Fi")]
   #[serde(rename(serialize = "Sci-Fi"))]
-  /// SciFi
   SciFi = 21,
   /// Short
   Short = 22,
   /// Sport
   Sport = 23,
+  /// TalkShow
   #[display(fmt = "Talk-Show")]
   #[enumeration(rename = "Talk-Show")]
   #[serde(rename(serialize = "Talk-Show"))]
-  /// TalkShow
   TalkShow = 24,
   /// Thriller
   Thriller = 25,
@@ -91,7 +91,7 @@ impl Genre {
     Self::Experimental as u8
   }
 
-  /// Converts a number into its corresponding Genre item
+  /// Converts a number into its corresponding Genre item.
   ///
   /// # Arguments
   ///

--- a/lib/src/imdb/service.rs
+++ b/lib/src/imdb/service.rs
@@ -10,7 +10,7 @@ use crate::imdb::db_binary::ServiceDbFromBinary;
 use crate::imdb::title::Title;
 use crate::imdb::title_id::TitleId;
 use crate::imdb::tsv_import::tsv_import;
-use crate::utils::io::ProgressPipe;
+use crate::utils::io::progress::ProgressPipe;
 use crate::utils::result::Res;
 use crate::utils::search::SearchString;
 

--- a/lib/src/imdb/title.rs
+++ b/lib/src/imdb/title.rs
@@ -16,7 +16,7 @@ use std::io::Write;
 use std::str::FromStr;
 use std::time::Duration;
 
-/// Wraps a title based on its type
+/// Wraps a title based on its type.
 #[derive(Debug, Clone, Copy)]
 pub(crate) enum TsvAction<T> {
   Skip,

--- a/lib/src/imdb/title_type.rs
+++ b/lib/src/imdb/title_type.rs
@@ -15,21 +15,21 @@ pub enum TitleType {
   VideoGame = 0,
 
   // Movies
+  /// Short.
   #[display(fmt = "Short Movie")]
-  /// Short
   Short = 1,
   /// Video
   Video = 2,
   /// Movie
   Movie = 3,
+  /// TvShort.
   #[display(fmt = "TV Short")]
-  /// TvShort
   TvShort = 4,
+  /// TvMovie.
   #[display(fmt = "TV Movie")]
-  /// TvMovie
   TvMovie = 5,
+  /// TvSpecial.
   #[display(fmt = "TV Special")]
-  /// TvSpecial
   TvSpecial = 6,
 
   // Episodes
@@ -41,16 +41,16 @@ pub enum TitleType {
   RadioEpisode = 9,
 
   // Series
+  /// TvSeries.
   #[display(fmt = "TV Series")]
-  /// TvSeries
   TvSeries = 10,
+  /// TvMiniSeries.
   #[display(fmt = "TV Mini-Series")]
-  /// TvMiniSeries
   TvMiniSeries = 11,
 
   // Radio
+  /// RadioSeries.
   #[display(fmt = "Radio Series")]
-  /// RadioSeries
   RadioSeries = 12,
 }
 

--- a/lib/src/utils/io/file.rs
+++ b/lib/src/utils/io/file.rs
@@ -1,0 +1,49 @@
+#![warn(clippy::all)]
+
+//! Helpers for file handling.
+
+use std::fs::File;
+use std::io;
+use std::path::Path;
+use std::time::{Duration, SystemTime};
+
+use crate::utils::result::Res;
+
+/// Returns the file at the given path if it exists, or an Ok Result if it is not found.
+///
+/// Only returns an error if a problem occurs while opening an existing file.
+///
+/// # Arguments
+///
+/// * `path` - Path of the file to be opened.
+pub fn file_exists(path: &Path) -> Res<Option<File>> {
+  match File::open(path) {
+    Ok(f) => Ok(Some(f)),
+    Err(e) => match e.kind() {
+      io::ErrorKind::NotFound => Ok(None),
+      _ => Err(Box::new(e)),
+    },
+  }
+}
+
+/// Determines if the given database file is old.
+///
+/// # Arguments
+///
+/// * `file` - Database file to be checked.
+/// * `duration` - The duration by which the file would be considered old.
+pub fn file_older_than(file: &Option<File>, duration: Duration) -> bool {
+  if let Some(f) = file {
+    if let Ok(md) = f.metadata() {
+      if let Ok(modified) = md.modified() {
+        match SystemTime::now().duration_since(modified) {
+          Ok(age) => return age >= duration,
+          Err(_) => return true,
+        }
+      }
+    }
+  }
+
+  // The file does not exist or its metadata or modification date could not be read.
+  true
+}

--- a/lib/src/utils/io/file.rs
+++ b/lib/src/utils/io/file.rs
@@ -2,8 +2,8 @@
 
 //! Helpers for file handling.
 
-use std::fs::File;
-use std::io;
+use std::fs::{self, File};
+use std::io::{self, BufWriter};
 use std::path::Path;
 use std::time::{Duration, SystemTime};
 
@@ -46,4 +46,22 @@ pub fn older_than(file: &Option<File>, duration: Duration) -> bool {
 
   // The file does not exist or its metadata or modification date could not be read.
   true
+}
+
+/// Reads the contents of a file into a leaked static buffer.
+///
+/// # Arguments
+///
+/// * `file` - The file path to read.
+pub fn read_static(filename: &Path) -> Res<&'static [u8]> {
+  Ok(Box::leak(fs::read(filename)?.into_boxed_slice()))
+}
+
+/// Creates a file and returns a buffered writer handle to it.
+///
+/// # Arguments
+///
+/// * `file` - The file path to create.
+pub fn create_buffered(filename: &Path) -> Res<BufWriter<File>> {
+  Ok(BufWriter::new(File::create(filename)?))
 }

--- a/lib/src/utils/io/file.rs
+++ b/lib/src/utils/io/file.rs
@@ -16,7 +16,7 @@ use crate::utils::result::Res;
 /// # Arguments
 ///
 /// * `path` - Path of the file to be opened.
-pub fn file_exists(path: &Path) -> Res<Option<File>> {
+pub fn open_existing(path: &Path) -> Res<Option<File>> {
   match File::open(path) {
     Ok(f) => Ok(Some(f)),
     Err(e) => match e.kind() {
@@ -32,7 +32,7 @@ pub fn file_exists(path: &Path) -> Res<Option<File>> {
 ///
 /// * `file` - Database file to be checked.
 /// * `duration` - The duration by which the file would be considered old.
-pub fn file_older_than(file: &Option<File>, duration: Duration) -> bool {
+pub fn older_than(file: &Option<File>, duration: Duration) -> bool {
   if let Some(f) = file {
     if let Ok(md) = f.metadata() {
       if let Ok(modified) = md.modified() {

--- a/lib/src/utils/io/mod.rs
+++ b/lib/src/utils/io/mod.rs
@@ -1,0 +1,6 @@
+#![warn(clippy::all)]
+#![warn(missing_docs)]
+
+//! Common utilities for things like networking and IO.
+
+pub mod progress;

--- a/lib/src/utils/io/mod.rs
+++ b/lib/src/utils/io/mod.rs
@@ -3,4 +3,5 @@
 
 //! Common utilities for things like networking and IO.
 
+pub mod file;
 pub mod progress;

--- a/lib/src/utils/io/mod.rs
+++ b/lib/src/utils/io/mod.rs
@@ -4,4 +4,5 @@
 //! Common utilities for things like networking and IO.
 
 pub mod file;
+pub mod net;
 pub mod progress;

--- a/lib/src/utils/io/net.rs
+++ b/lib/src/utils/io/net.rs
@@ -1,0 +1,36 @@
+#![warn(clippy::all)]
+
+//! Helpers for networking.
+
+use std::io::{BufRead, BufReader};
+
+use crate::utils::io::progress::ProgressPipe;
+use crate::utils::result::Res;
+
+use flate2::bufread::GzDecoder;
+use reqwest::blocking::{Client, Response};
+use reqwest::Url;
+
+/// Sends a GET request to the given URL and returns the response.
+///
+/// # Arguments
+///
+/// * `url` - The URL to send the GET request to.
+pub fn get_response(url: Url) -> Res<Response> {
+  let client = Client::builder().build()?;
+  let resp = client.get(url).send()?;
+  Ok(resp)
+}
+
+/// Returns a reader for the given response.
+///
+/// # Arguments
+///
+/// * `resp` - Response returned for the GET request.
+/// * `progress_fn` - Function to keep track of the download progress.
+pub fn create_fetcher(resp: Response, progress_fn: impl Fn(u64)) -> impl BufRead {
+  let progress = ProgressPipe::new(resp, progress_fn);
+  let reader = BufReader::new(progress);
+  let decoder = GzDecoder::new(reader);
+  BufReader::new(decoder)
+}

--- a/lib/src/utils/io/net.rs
+++ b/lib/src/utils/io/net.rs
@@ -28,7 +28,7 @@ pub fn get_response(url: Url) -> Res<Response> {
 ///
 /// * `resp` - Response returned for the GET request.
 /// * `progress_fn` - Function to keep track of the download progress.
-pub fn create_fetcher(resp: Response, progress_fn: impl Fn(u64)) -> impl BufRead {
+pub fn make_fetcher(resp: Response, progress_fn: impl Fn(u64)) -> impl BufRead {
   let progress = ProgressPipe::new(resp, progress_fn);
   let reader = BufReader::new(progress);
   let decoder = GzDecoder::new(reader);

--- a/lib/src/utils/io/progress.rs
+++ b/lib/src/utils/io/progress.rs
@@ -1,6 +1,6 @@
 #![warn(clippy::all)]
 
-//! Common utilities for IO.
+//! Helper for showing IO progress using a callback mechanism.
 
 use std::io::Read;
 


### PR DESCRIPTION
This takes some common tasks whose functions were lurking in the `imdb::service` module and moves them under the more generic `utils` module. There are a few renames as well.