### PR TITLE
Improve library and cli error handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1537,6 +1537,8 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
+ "thiserror",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1559,8 +1559,10 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "thiserror",
  "truncatable",
  "tvrank",
+ "url",
  "walkdir",
 ]
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -33,3 +33,5 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml = "0.8"
 prettytable-rs = "0.10"
+url = "2.2"
+thiserror = "1.0"

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -29,6 +29,8 @@ humantime = "2.1"
 parking_lot = "0.12"
 log = "0.4"
 enum-utils = "0.1"
+url = "2.2"
+thiserror = "1.0"
 
 [dev-dependencies]
 indoc = "1.0"

--- a/lib/examples/query.rs
+++ b/lib/examples/query.rs
@@ -1,10 +1,11 @@
 #![warn(clippy::all)]
 
+use std::error::Error;
+
 use tvrank::imdb::{Imdb, ImdbQuery};
-use tvrank::utils::result::Res;
 use tvrank::utils::search::SearchString;
 
-fn main() -> Res {
+fn main() -> Result<(), Box<dyn Error>> {
   let cache_dir = tempfile::Builder::new().prefix("tvrank_").tempdir()?;
   let imdb = Imdb::new(cache_dir.path(), false, |_, _| {})?;
 

--- a/lib/src/imdb/db_binary.rs
+++ b/lib/src/imdb/db_binary.rs
@@ -1,12 +1,22 @@
 #![warn(clippy::all)]
 
-use super::db::Db;
+use crate::imdb::db::{Db, Query};
 use crate::imdb::title::Title;
 use crate::imdb::title_id::TitleId;
-use crate::{imdb::db::Query, utils::search::SearchString};
+use crate::utils::search::SearchString;
+
 use log::debug;
 use parking_lot::{const_mutex, Mutex};
 use rayon::prelude::*;
+
+/// Errors when loading database.
+#[derive(Debug, thiserror::Error)]
+#[error("Error loading database")]
+pub enum Error {
+  /// Loading title error.
+  #[error("Error loading title: {0}")]
+  LoadingTitle(#[from] crate::imdb::title::Error),
+}
 
 pub struct ServiceDbFromBinary {
   dbs: Vec<Db>,
@@ -22,29 +32,47 @@ impl ServiceDbFromBinary {
   ///
   /// * `movies_data` - Binary movies data.
   /// * `series_data` - Binary series data.
-  pub(crate) fn new(mut movies_data: &'static [u8], mut series_data: &'static [u8]) -> Self {
+  pub(crate) fn new(mut movies_data: &'static [u8], mut series_data: &'static [u8]) -> Result<Self, Error> {
     let nthreads = rayon::current_num_threads();
     let dbs = const_mutex(Vec::with_capacity(nthreads));
     let movies_cursor: Mutex<&mut &'static [u8]> = const_mutex(&mut movies_data);
     let series_cursor: Mutex<&mut &'static [u8]> = const_mutex(&mut series_data);
+    let error: Mutex<Option<Error>> = const_mutex(None);
 
     rayon::scope(|scope| {
       for _ in 0..nthreads {
         let dbs = &dbs;
         let movies_cursor = &movies_cursor;
         let series_cursor = &series_cursor;
+        let error_mutex = &error;
 
         scope.spawn(move |_| {
           let mut db = Db::with_capacities(1_900_000 / nthreads, 270_000 / nthreads);
           let mut titles = Vec::with_capacity(100);
-          Self::movies_from_binary(movies_cursor, &mut titles, &mut db);
-          Self::series_from_binary(series_cursor, &mut titles, &mut db);
+          if let Err(err) = Self::movies_from_binary(movies_cursor, &mut titles, &mut db) {
+            let mut error_guard = error_mutex.lock();
+            if error_guard.is_none() {
+              *error_guard = Some(err);
+            }
+            return;
+          }
+          if let Err(err) = Self::series_from_binary(series_cursor, &mut titles, &mut db) {
+            let mut error_guard = error_mutex.lock();
+            if error_guard.is_none() {
+              *error_guard = Some(err);
+            }
+            return;
+          }
           dbs.lock().push(db);
         });
       }
     });
 
-    Self { dbs: dbs.into_inner() }
+    if let Some(err) = error.into_inner() {
+      Err(err)
+    } else {
+      Ok(Self { dbs: dbs.into_inner() })
+    }
   }
 
   /// Loads movies from the provided binary content buffers.
@@ -54,7 +82,11 @@ impl ServiceDbFromBinary {
   /// * `cursor` - Cursor at the binary to read the titles from.
   /// * `titles` - Vector to store the titles temporarily before writing to the database.
   /// * `db` - Database to store movies in.
-  fn movies_from_binary(cursor: &Mutex<&mut &'static [u8]>, titles: &mut Vec<Title<'static>>, db: &mut Db) {
+  fn movies_from_binary(
+    cursor: &Mutex<&mut &'static [u8]>,
+    titles: &mut Vec<Title<'static>>,
+    db: &mut Db,
+  ) -> Result<(), Error> {
     Self::titles_from_binary::<true>(cursor, titles, db)
   }
 
@@ -65,7 +97,11 @@ impl ServiceDbFromBinary {
   /// * `cursor` - Cursor at the binary to read the titles from.
   /// * `titles` - Vector to store the titles temporarily before writing to the database.
   /// * `db` - Database to store series in.
-  fn series_from_binary(cursor: &Mutex<&mut &'static [u8]>, titles: &mut Vec<Title<'static>>, db: &mut Db) {
+  fn series_from_binary(
+    cursor: &Mutex<&mut &'static [u8]>,
+    titles: &mut Vec<Title<'static>>,
+    db: &mut Db,
+  ) -> Result<(), Error> {
     Self::titles_from_binary::<false>(cursor, titles, db)
   }
 
@@ -85,12 +121,12 @@ impl ServiceDbFromBinary {
     cursor: &Mutex<&mut &'static [u8]>,
     titles: &mut Vec<Title<'static>>,
     db: &mut Db,
-  ) {
+  ) -> Result<(), Error> {
     loop {
       let mut cursor_guard = cursor.lock();
 
       if (*cursor_guard).is_empty() {
-        break;
+        return Ok(());
       }
 
       for _ in 0..100 {
@@ -98,11 +134,7 @@ impl ServiceDbFromBinary {
           break;
         }
 
-        let title = match Title::from_binary(&mut cursor_guard) {
-          Ok(title) => title,
-          Err(e) => panic!("Error parsing title: {e}"),
-        };
-
+        let title = Title::from_binary(&mut cursor_guard)?;
         titles.push(title);
       }
 
@@ -217,7 +249,7 @@ mod tests {
 
     let movies_storage = Box::leak(movies_storage.into_boxed_slice());
     let series_storage = Box::leak(series_storage.into_boxed_slice());
-    ServiceDbFromBinary::new(movies_storage, series_storage)
+    ServiceDbFromBinary::new(movies_storage, series_storage).unwrap()
   }
 
   #[test]

--- a/lib/src/imdb/mod.rs
+++ b/lib/src/imdb/mod.rs
@@ -6,7 +6,6 @@
 mod db;
 mod db_binary;
 mod db_impl;
-mod error;
 mod genre;
 mod ratings;
 mod service;
@@ -21,9 +20,10 @@ mod tsv_import;
 mod testdata;
 
 pub use db::Query as ImdbQuery;
-pub use error::Err as ImdbErr;
 pub use genre::{Genre as ImdbGenre, Genres as ImdbGenres};
+pub use service::Error as ImdbError;
 pub use service::Service as Imdb;
 pub use title::Title as ImdbTitle;
+pub use title_id::Error as ImdbTitleIdError;
 pub use title_id::TitleId as ImdbTitleId;
 pub use title_type::TitleType as ImdbTitleType;

--- a/lib/src/imdb/ratings.rs
+++ b/lib/src/imdb/ratings.rs
@@ -1,19 +1,46 @@
 #![warn(clippy::all)]
 
-use crate::imdb::error::Err;
 use crate::imdb::title_id::TitleId;
 use crate::imdb::tokens;
 use crate::iter_next;
-use crate::utils::result::Res;
+
+use std::borrow::Borrow;
+use std::cmp::{Ord, Ordering};
+use std::io::{self, BufRead};
+use std::num::ParseFloatError;
+use std::ops::{Deref, DerefMut};
+use std::str::FromStr;
+
 use atoi::atoi;
 use fnv::FnvHashMap;
 use serde::Serialize;
-use std::borrow::Borrow;
-use std::cmp::Ord;
-use std::cmp::Ordering;
-use std::io::BufRead;
-use std::ops::{Deref, DerefMut};
-use std::str::FromStr;
+
+/// Errors when converting titles from IMDB TSVs to binary.
+#[derive(Debug, thiserror::Error)]
+#[error("Error parsing title rating")]
+pub enum Error {
+  /// Title parsing error.
+  #[error("Title parsing error: {0}")]
+  TitleParsing(#[from] crate::imdb::title::Error),
+  /// IO errors.
+  #[error("IO error: {0}")]
+  Io(#[from] io::Error),
+  /// Number of votes is not a valid number.
+  #[error("Number of votes is not a valid number")]
+  Votes,
+  /// ID already exists.
+  #[error("Duplicate IMDB ID `{0}` found")]
+  DuplicateId(String),
+  /// Invalid rating value.
+  #[error("Invalid rating value `{0}`")]
+  InvalidRating(String, #[source] ParseFloatError),
+  /// General parsing errors.
+  #[error("Parsing error: {0}")]
+  Parsing(#[from] crate::utils::tokens::Error),
+  /// ID parsing errors.
+  #[error("Error parsing ID: {0}")]
+  IdParsing(#[from] crate::imdb::title_id::Error),
+}
 
 /// Average user rating of a title together with the number of votes
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Serialize)]
@@ -55,10 +82,11 @@ impl Rating {
 
   /// Creates a Rating from a tab separated value
   /// * `columns` - Rating of a title as a tab separated value
-  fn from_tsv<'a>(columns: &mut impl Iterator<Item = &'a [u8]>) -> Res<Self> {
-    let rating = f32::from_str(unsafe { std::str::from_utf8_unchecked(iter_next!(columns)) })?;
+  fn from_tsv<'a>(columns: &mut impl Iterator<Item = &'a [u8]>) -> Result<Self, Error> {
+    let rating = unsafe { std::str::from_utf8_unchecked(iter_next!(columns)?) };
+    let rating = f32::from_str(rating).map_err(|e| Error::InvalidRating(rating.to_owned(), e))?;
     let rating = unsafe { (rating * 10.0).to_int_unchecked() };
-    let votes = atoi::<u32>(iter_next!(columns)).ok_or(Err::Votes)?;
+    let votes = atoi::<u32>(iter_next!(columns)?).ok_or(Error::Votes)?;
     Ok(Self::new(rating, votes))
   }
 
@@ -114,7 +142,7 @@ impl DerefMut for Ratings {
 impl Ratings {
   /// Create and return Ratings from tab separated values
   /// * `reader` - Reader containing a list of titles as tab separated values
-  pub(crate) fn from_tsv<R: BufRead>(mut reader: R) -> Res<Self> {
+  pub(crate) fn from_tsv<R: BufRead>(mut reader: R) -> Result<Self, Error> {
     // TODO: See if we can use byte vectors instead of strings. Ultimately we end up
     // parsing bytes rather than strings, and when we need strings, we already know they
     // are valid UTF-8 because we trust the source.
@@ -141,11 +169,11 @@ impl Ratings {
 
       let mut columns = trimmed.as_bytes().split(|&b| b == tokens::TAB);
 
-      let id = TitleId::try_from(iter_next!(columns))?;
+      let id = TitleId::try_from(iter_next!(columns)?)?;
       let rating = Rating::from_tsv(&mut columns)?;
 
       if res.insert(id.as_usize(), rating).is_some() {
-        return Err::duplicate_id(id.as_str().to_owned());
+        return Err(Error::DuplicateId(id.as_str().to_owned()));
       }
 
       line.clear();

--- a/lib/src/imdb/service.rs
+++ b/lib/src/imdb/service.rs
@@ -10,14 +10,34 @@ use crate::imdb::title_id::TitleId;
 use crate::imdb::tsv_import::tsv_import;
 use crate::utils::io::file as io_file;
 use crate::utils::io::net as io_net;
-use crate::utils::result::Res;
 use crate::utils::search::SearchString;
 
 use humantime::format_duration;
 use log::{debug, log_enabled};
 use reqwest::Url;
 
-/// Struct providing the movies and series databases and the related services
+/// Errors when creating service.
+#[derive(Debug, thiserror::Error)]
+#[error("Error creating IMDB service")]
+pub enum Error {
+  /// File-related error.
+  #[error("File handling error: {0}")]
+  File(#[from] crate::utils::io::file::Error),
+  /// Networking-related error.
+  #[error("Network handling error: {0}")]
+  Net(#[from] crate::utils::io::net::Error),
+  /// Database loading error.
+  #[error("Error loading database: {0}")]
+  Db(#[from] crate::imdb::db_binary::Error),
+  /// URL parsing error.
+  #[error("Error parsing URL: {0}")]
+  UrlParsing(#[from] url::ParseError),
+  /// TSV conversion error.
+  #[error("Error importing from TSV to binary database: {0}")]
+  TsvImport(#[from] crate::imdb::tsv_import::Error),
+}
+
+/// Struct providing the movies and series databases and the related services.
 pub struct Service {
   service_db: ServiceDbFromBinary,
 }
@@ -37,7 +57,11 @@ impl Service {
   /// * `cache_dir` - Directory path of the database files.
   /// * `force_db_update` - True if the databases should be updated regardless of their age.
   /// * `progress_fn` - Function that keeps track of the download progress.
-  pub fn new(cache_dir: &Path, force_db_update: bool, progress_fn: impl Fn(Option<u64>, u64)) -> Res<Self> {
+  pub fn new(
+    cache_dir: &Path,
+    force_db_update: bool,
+    progress_fn: impl Fn(Option<u64>, u64),
+  ) -> Result<Self, Error> {
     let one_month = Duration::from_secs(60 * 60 * 24 * 30);
 
     let movies_db_filename = cache_dir.join(MOVIES_DB_FILENAME);
@@ -50,7 +74,7 @@ impl Service {
     debug!("Read IMDB database in {}", format_duration(Instant::now().duration_since(start)));
 
     let start = Instant::now();
-    let service = Self { service_db: ServiceDbFromBinary::new(movies_data, series_data) };
+    let service = Self { service_db: ServiceDbFromBinary::new(movies_data, series_data)? };
     debug!("Parsed IMDB database in {}", format_duration(Instant::now().duration_since(start)));
 
     if log_enabled!(log::Level::Debug) {
@@ -79,7 +103,7 @@ impl Service {
     max_age: Duration,
     force_db_update: bool,
     progress_fn: impl Fn(Option<u64>, u64),
-  ) -> Res {
+  ) -> Result<(), Error> {
     let needs_update = {
       force_db_update
         || io_file::older_than(&io_file::open_existing(movies_db_filename)?, max_age)

--- a/lib/src/imdb/title.rs
+++ b/lib/src/imdb/title.rs
@@ -1,6 +1,5 @@
 #![warn(clippy::all)]
 
-use crate::imdb::error::Err;
 use crate::imdb::genre::{Genre, Genres};
 use crate::imdb::ratings::{Rating, Ratings};
 use crate::imdb::title_header::TitleHeader;
@@ -8,13 +7,15 @@ use crate::imdb::title_id::TitleId;
 use crate::imdb::title_type::TitleType;
 use crate::imdb::tokens;
 use crate::iter_next;
-use crate::utils::result::Res;
-use atoi::atoi;
-use serde::Serialize;
+
+use std::array::TryFromSliceError;
 use std::hash::{Hash, Hasher};
-use std::io::Write;
+use std::io::{self, Write};
 use std::str::FromStr;
 use std::time::Duration;
+
+use atoi::atoi;
+use serde::Serialize;
 
 /// Wraps a title based on its type.
 #[derive(Debug, Clone, Copy)]
@@ -34,7 +35,46 @@ impl<T> From<TsvAction<T>> for Option<T> {
   }
 }
 
-/// Primary/original titles of a movie/series and its relevant information such as duration and rating
+/// Errors when parsing title information.
+#[derive(Debug, thiserror::Error)]
+#[error("Title error")]
+pub enum Error {
+  /// Title type does not exist.
+  #[error("Unknown title type")]
+  TitleType,
+  /// Title type is not supported.
+  #[error("Unknown title type `{0}`")]
+  UnsupportedTitleType(TitleType),
+  /// Adult marker is invalid.
+  #[error("Invalid adult marker")]
+  Adult,
+  /// Start year is not a number.
+  #[error("Start year is not a number")]
+  StartYear,
+  /// End year is not a number.
+  #[error("End year is not a number")]
+  EndYear,
+  /// Runtime minutes is not a number.
+  #[error("Runtime minutes is not a number")]
+  RuntimeMinutes,
+  /// Given genre is invalid.
+  #[error("Invalid or unknown genre `{0}`")]
+  Genre(String),
+  /// General parsing errors.
+  #[error("Parsing error: {0}")]
+  Parsing(#[from] crate::utils::tokens::Error),
+  /// ID parsing errors.
+  #[error("Error parsing ID: {0}")]
+  IdParsing(#[from] crate::imdb::title_id::Error),
+  /// Binary parsing errors.
+  #[error("Error parsing binary content: {0}")]
+  BinParsing(#[from] TryFromSliceError),
+  /// IO errors.
+  #[error("IO error: {0}")]
+  Io(#[from] io::Error),
+}
+
+/// Title information.
 #[derive(Debug, Clone, Copy, Serialize)]
 pub struct Title<'storage> {
   #[serde(flatten)]
@@ -60,37 +100,37 @@ impl Hash for Title<'_> {
 }
 
 impl<'storage> Title<'storage> {
-  /// Returns the id of the title
+  /// Returns the id of the title.
   pub fn title_id(&self) -> &TitleId {
     &self.title_id
   }
 
-  /// Returns the type of the title (e.g. Movie, Series etc.)
+  /// Returns the type of the title (e.g. Game, TV Movies, Short Movie, etc).
   pub fn title_type(&self) -> TitleType {
     self.header.title_type()
   }
 
-  /// Returns the primary title in English
+  /// Returns the primary title in English.
   pub fn primary_title(&self) -> &str {
     self.primary_title
   }
 
-  /// Returns an Option containing the original title in the original language if exists
+  /// Returns the original title in the original language if it exists.
   pub fn original_title(&self) -> Option<&str> {
     self.original_title
   }
 
-  /// Returns if the title is rated R
+  /// Returns if the title is rated R.
   pub fn is_adult(&self) -> bool {
     self.header.is_adult()
   }
 
-  /// Returns the release date of the title
+  /// Returns the release date of the title.
   pub fn start_year(&self) -> Option<u16> {
     self.header.start_year()
   }
 
-  /// Returns the duration of the title
+  /// Returns the duration of the title.
   pub fn runtime(&self) -> Option<Duration> {
     self
       .header
@@ -98,29 +138,31 @@ impl<'storage> Title<'storage> {
       .map(|runtime| Duration::from_secs(u64::from(runtime) * 60))
   }
 
-  /// Returns the set of genres associated with the title
+  /// Returns the set of genres associated with the title.
   pub fn genres(&self) -> Genres {
     self.header.genres()
   }
 
-  /// Returns the rating of the title
+  /// Returns the rating of the title.
   pub fn rating(&self) -> Option<Rating> {
     self.header.rating()
   }
 
   /// Reads a title from tab separated values and returns it inside a TsvAction struct
+  ///
   /// # Arguments
-  /// * `line` - A title as tab separated values
-  /// * `ratings` - Ratings struct containing the ratings of the titles
-  pub(crate) fn from_tsv(line: &'storage [u8], ratings: &Ratings) -> Res<TsvAction<Self>> {
+  ///
+  /// * `line` - A title as tab separated values.
+  /// * `ratings` - Ratings struct containing the ratings of the titles.
+  pub(crate) fn from_tsv(line: &'storage [u8], ratings: &Ratings) -> Result<TsvAction<Self>, Error> {
     let mut columns = line.split(|&b| b == tokens::TAB);
 
-    let title_id = TitleId::try_from(iter_next!(columns))?;
+    let title_id = TitleId::try_from(iter_next!(columns)?)?;
 
     let title_type = {
-      let title_type = iter_next!(columns);
+      let title_type = iter_next!(columns)?;
       let title_type = unsafe { std::str::from_utf8_unchecked(title_type) };
-      TitleType::from_str(title_type).map_err(|_| Err::TitleType)?
+      TitleType::from_str(title_type).map_err(|_| Error::TitleType)?
     };
 
     let is_movie = title_type.is_movie();
@@ -130,8 +172,8 @@ impl<'storage> Title<'storage> {
       return Ok(TsvAction::Skip);
     }
 
-    let primary_title = unsafe { std::str::from_utf8_unchecked(iter_next!(columns)) };
-    let original_title = unsafe { std::str::from_utf8_unchecked(iter_next!(columns)) };
+    let primary_title = unsafe { std::str::from_utf8_unchecked(iter_next!(columns)?) };
+    let original_title = unsafe { std::str::from_utf8_unchecked(iter_next!(columns)?) };
     let original_title = if original_title.to_lowercase() == primary_title.to_lowercase() {
       None
     } else {
@@ -139,11 +181,11 @@ impl<'storage> Title<'storage> {
     };
 
     let is_adult = {
-      let is_adult = iter_next!(columns);
+      let is_adult = iter_next!(columns)?;
       match is_adult {
         tokens::ZERO => false,
         tokens::ONE => true,
-        _ => return Err::adult(),
+        _ => return Err(Error::Adult),
       }
     };
 
@@ -152,38 +194,38 @@ impl<'storage> Title<'storage> {
     }
 
     let start_year = {
-      let start_year = iter_next!(columns);
+      let start_year = iter_next!(columns)?;
       match start_year {
         tokens::NOT_AVAIL => None,
-        start_year => Some(atoi::<u16>(start_year).ok_or(Err::StartYear)?),
+        start_year => Some(atoi::<u16>(start_year).ok_or(Error::StartYear)?),
       }
     };
 
     let _end_year = {
-      let end_year = iter_next!(columns);
+      let end_year = iter_next!(columns)?;
       match end_year {
         tokens::NOT_AVAIL => None,
-        end_year => Some(atoi::<u16>(end_year).ok_or(Err::EndYear)?),
+        end_year => Some(atoi::<u16>(end_year).ok_or(Error::EndYear)?),
       }
     };
 
     let runtime_minutes = {
-      let runtime_minutes = iter_next!(columns);
+      let runtime_minutes = iter_next!(columns)?;
       match runtime_minutes {
         tokens::NOT_AVAIL => None,
-        runtime_minutes => Some(atoi::<u16>(runtime_minutes).ok_or(Err::RuntimeMinutes)?),
+        runtime_minutes => Some(atoi::<u16>(runtime_minutes).ok_or(Error::RuntimeMinutes)?),
       }
     };
 
     let genres = {
-      let genres = iter_next!(columns);
+      let genres = iter_next!(columns)?;
       let mut result = Genres::default();
 
       if genres != tokens::NOT_AVAIL {
         let genres = genres.split(|&b| b == tokens::COMMA);
         for genre in genres {
           let genre = unsafe { std::str::from_utf8_unchecked(genre) };
-          let genre = Genre::from_str(genre).map_err(|_| Err::Genre)?;
+          let genre = Genre::from_str(genre).map_err(|_| Error::Genre(genre.to_owned()))?;
           result.add(genre);
         }
       }
@@ -209,28 +251,30 @@ impl<'storage> Title<'storage> {
     } else if is_series {
       Ok(TsvAction::Series(title))
     } else {
-      Err::unsupported_title_type(title_type)
+      Err(Error::UnsupportedTitleType(title_type))
     }
   }
 
-  /// Writes the title as binary
+  /// Writes a title in binary format.
+  ///
   /// # Arguments
-  /// `writer` - Writer to write the title to
-  pub(crate) fn write_binary<W: Write>(&self, writer: &mut W) -> Res {
+  ///
+  /// `writer` - Writer to write the title to.
+  pub(crate) fn write_binary<W: Write>(&self, writer: &mut W) -> Result<(), Error> {
     writer.write_all(&self.header.to_le_bytes())?;
 
     let title_id = self.title_id.as_bytes();
     writer.write_all(&(title_id.len() as u8).to_le_bytes())?;
     writer.write_all(title_id)?;
 
-    let primary_title = self.primary_title.as_bytes();
-    writer.write_all(&(primary_title.len() as u16).to_le_bytes())?;
-    writer.write_all(primary_title)?;
+    let primary = self.primary_title.as_bytes();
+    writer.write_all(&(primary.len() as u16).to_le_bytes())?;
+    writer.write_all(primary)?;
 
-    if let Some(original_title) = self.original_title {
-      let original_title = original_title.as_bytes();
-      writer.write_all(&(original_title.len() as u16).to_le_bytes())?;
-      writer.write_all(original_title)?;
+    if let Some(original) = self.original_title {
+      let original = original.as_bytes();
+      writer.write_all(&(original.len() as u16).to_le_bytes())?;
+      writer.write_all(original)?;
     }
 
     Ok(())
@@ -239,7 +283,7 @@ impl<'storage> Title<'storage> {
   /// Reads a title from its binary representation and returns it inside a Result
   /// # Arguments
   /// * `source` - Title to be read as binary
-  pub(crate) fn from_binary(source: &mut &'storage [u8]) -> Res<Self> {
+  pub(crate) fn from_binary(source: &mut &'storage [u8]) -> Result<Self, Error> {
     if (*source).len() < 23 {
       // # 23 bytes:
       //
@@ -249,7 +293,7 @@ impl<'storage> Title<'storage> {
       // * 2 bytes for the primary title length
       // * At least 1 byte for the primary title
 
-      return Err::eof();
+      return Err(crate::utils::tokens::Error::Eof)?;
     }
 
     let header: [u8; 16] = source[..16].try_into()?;

--- a/lib/src/imdb/title_id.rs
+++ b/lib/src/imdb/title_id.rs
@@ -1,12 +1,24 @@
 #![warn(clippy::all)]
 
-use crate::imdb::error::Err;
 use crate::imdb::tokens;
-use atoi::FromRadix10;
-use serde::{Serialize, Serializer};
-use std::error::Error;
+
 use std::fmt;
 use std::hash::{Hash, Hasher};
+
+use atoi::FromRadix10;
+use serde::{Serialize, Serializer};
+
+/// Errors when parsing title IDs.
+#[derive(Debug, thiserror::Error)]
+#[error("Error parsing title ID")]
+pub enum Error {
+  /// ID does not start with the required `tt`.
+  #[error("ID `{0}` does not start with `tt` (e.g. ttXXXXXXX)")]
+  Id(String),
+  /// ID does not contain a valid number.
+  #[error("ID `{0}` does not contain a valid number (e.g. ttXXXXXXX)")]
+  IdNumber(String),
+}
 
 /// The ID corresponding to a title as u8 and usize
 #[derive(Debug, Clone, Copy)]
@@ -56,18 +68,18 @@ impl<'storage> TitleId<'storage> {
 }
 
 impl<'storage> TryFrom<&'storage [u8]> for TitleId<'storage> {
-  type Error = Box<dyn Error>;
+  type Error = Error;
 
   fn try_from(bytes: &'storage [u8]) -> Result<Self, Self::Error> {
     if &bytes[0..2] != tokens::TT {
-      return Err::id(unsafe { std::str::from_utf8_unchecked(bytes) }.to_owned());
+      return Err(Error::Id(unsafe { std::str::from_utf8_unchecked(bytes) }.to_owned()));
     }
 
     let num = &bytes[2..];
     let num_len = num.len();
     let num = match usize::from_radix_10(num) {
       (val, len) if len == num_len => val,
-      _ => return Err::id_number(unsafe { std::str::from_utf8_unchecked(bytes) }.to_owned()),
+      _ => return Err(Error::IdNumber(unsafe { std::str::from_utf8_unchecked(bytes) }.to_owned())),
     };
 
     Ok(TitleId { bytes, num })
@@ -75,7 +87,7 @@ impl<'storage> TryFrom<&'storage [u8]> for TitleId<'storage> {
 }
 
 impl<'a> TryFrom<&'a str> for TitleId<'a> {
-  type Error = Box<dyn Error>;
+  type Error = Error;
 
   fn try_from(id: &'a str) -> Result<Self, Self::Error> {
     TitleId::try_from(id.as_bytes())

--- a/lib/src/imdb/title_type.rs
+++ b/lib/src/imdb/title_type.rs
@@ -5,22 +5,22 @@ use enum_utils::FromStr;
 use serde::Serialize;
 use std::hash::Hash;
 
-/// Encodes the 13 types a title can be
+/// Encodes the 13 types of a title.
 #[derive(Debug, Display, FromStr, PartialEq, Eq, Hash, Clone, Copy, Serialize)]
 #[enumeration(rename_all = "camelCase")]
 #[display(fmt = "{}")]
 pub enum TitleType {
   // Games
-  /// VideoGame
+  /// VideoGame.
   VideoGame = 0,
 
   // Movies
   /// Short.
   #[display(fmt = "Short Movie")]
   Short = 1,
-  /// Video
+  /// Video.
   Video = 2,
-  /// Movie
+  /// Movie.
   Movie = 3,
   /// TvShort.
   #[display(fmt = "TV Short")]
@@ -33,11 +33,11 @@ pub enum TitleType {
   TvSpecial = 6,
 
   // Episodes
-  /// TvEpisode
+  /// TvEpisode.
   TvEpisode = 7,
-  /// TvPilot
+  /// TvPilot.
   TvPilot = 8,
-  /// RadioEpisode
+  /// RadioEpisode.
   RadioEpisode = 9,
 
   // Series
@@ -55,14 +55,16 @@ pub enum TitleType {
 }
 
 impl TitleType {
-  /// Converts a byte representation to its corresponding TitleType
+  /// Converts a byte representation to its corresponding TitleType.
+  ///
   /// # Arguments
-  /// * `value` - Byte representation of a TitleType
+  ///
+  /// * `value` - Byte representation of a TitleType.
   pub(crate) const unsafe fn from(value: u8) -> Self {
     std::mem::transmute(value)
   }
 
-  /// Returns true if the TitleType is movie
+  /// Whether the title type refers to a movie.
   pub(crate) fn is_movie(&self) -> bool {
     match self {
       // Games
@@ -87,7 +89,7 @@ impl TitleType {
     }
   }
 
-  /// Returns true if the TitleType is series
+  /// Whether the title type refers to a series.
   pub(crate) fn is_series(&self) -> bool {
     match self {
       // Games

--- a/lib/src/title_info.rs
+++ b/lib/src/title_info.rs
@@ -2,22 +2,26 @@
 
 //! Module for handling title information objects.
 
-use crate::imdb::ImdbTitleId;
-use crate::utils::result::Res;
-use derive_more::Display;
-use log::warn;
-use serde::{Deserialize, Deserializer, Serialize};
-use std::error::Error;
 use std::fs;
-use std::io::BufReader;
+use std::io::{self, BufReader};
 use std::path::Path;
 
-/// Error type thrown when the title information file is incorrect.
-#[derive(Debug, Display)]
-#[display(fmt = "")]
-pub struct InfoErr;
+use crate::imdb::ImdbTitleId;
 
-impl Error for InfoErr {}
+use log::warn;
+use serde::{Deserialize, Deserializer, Serialize};
+
+/// Errors when parsing title information.
+#[derive(Debug, thiserror::Error)]
+#[error("Error parsing title information file")]
+pub enum Error {
+  /// JSON errors (e.g. when the title information file is incorrect).
+  #[error("Error parsing title info JSON file: {0}")]
+  Json(#[from] serde_json::Error),
+  /// IO errors.
+  #[error("IO error: {0}")]
+  Io(#[from] io::Error),
+}
 
 /// The IMDB section of title information files.
 #[derive(Serialize, Deserialize)]
@@ -65,7 +69,7 @@ impl<'a> TitleInfo<'a> {
   }
 
   /// Load a title information object from a file.
-  pub fn from_path(path: &Path) -> Res<TitleInfo> {
+  pub fn from_path(path: &Path) -> Result<TitleInfo, Error> {
     let title_info_path = path.join("tvrank.json");
     let title_info_file = fs::File::open(&title_info_path)?;
     let title_info_file_reader = BufReader::new(title_info_file);
@@ -75,7 +79,7 @@ impl<'a> TitleInfo<'a> {
       Ok(title_info) => title_info,
       Err(err) => {
         warn!("Ignoring info in `{}` due to parse error: {}", title_info_path.display(), err);
-        return Err(Box::new(InfoErr));
+        return Err(Error::Json(err));
       }
     };
 

--- a/lib/src/utils/io/file.rs
+++ b/lib/src/utils/io/file.rs
@@ -7,7 +7,14 @@ use std::io::{self, BufWriter};
 use std::path::Path;
 use std::time::{Duration, SystemTime};
 
-use crate::utils::result::Res;
+/// Errors when handling files.
+#[derive(Debug, thiserror::Error)]
+#[error("File handling error")]
+pub enum Error {
+  /// IO error.
+  #[error("IO error: {0}")]
+  Io(#[from] io::Error),
+}
 
 /// Returns the file at the given path if it exists, or an Ok Result if it is not found.
 ///
@@ -16,12 +23,12 @@ use crate::utils::result::Res;
 /// # Arguments
 ///
 /// * `path` - Path of the file to be opened.
-pub fn open_existing(path: &Path) -> Res<Option<File>> {
+pub fn open_existing(path: &Path) -> Result<Option<File>, Error> {
   match File::open(path) {
     Ok(f) => Ok(Some(f)),
     Err(e) => match e.kind() {
       io::ErrorKind::NotFound => Ok(None),
-      _ => Err(Box::new(e)),
+      _ => Err(Error::Io(e)),
     },
   }
 }
@@ -53,7 +60,7 @@ pub fn older_than(file: &Option<File>, duration: Duration) -> bool {
 /// # Arguments
 ///
 /// * `file` - The file path to read.
-pub fn read_static(filename: &Path) -> Res<&'static [u8]> {
+pub fn read_static(filename: &Path) -> Result<&'static [u8], Error> {
   Ok(Box::leak(fs::read(filename)?.into_boxed_slice()))
 }
 
@@ -62,6 +69,6 @@ pub fn read_static(filename: &Path) -> Res<&'static [u8]> {
 /// # Arguments
 ///
 /// * `file` - The file path to create.
-pub fn create_buffered(filename: &Path) -> Res<BufWriter<File>> {
+pub fn create_buffered(filename: &Path) -> Result<BufWriter<File>, Error> {
   Ok(BufWriter::new(File::create(filename)?))
 }

--- a/lib/src/utils/io/net.rs
+++ b/lib/src/utils/io/net.rs
@@ -5,18 +5,26 @@
 use std::io::{BufRead, BufReader};
 
 use crate::utils::io::progress::ProgressPipe;
-use crate::utils::result::Res;
 
 use flate2::bufread::GzDecoder;
 use reqwest::blocking::{Client, Response};
 use reqwest::Url;
+
+/// Errors when doing networking.
+#[derive(Debug, thiserror::Error)]
+#[error("Networking error")]
+pub enum Error {
+  /// Networking error.
+  #[error("Networking error: {0}")]
+  Net(#[from] reqwest::Error),
+}
 
 /// Sends a GET request to the given URL and returns the response.
 ///
 /// # Arguments
 ///
 /// * `url` - The URL to send the GET request to.
-pub fn get_response(url: Url) -> Res<Response> {
+pub fn get_response(url: Url) -> Result<Response, Error> {
   let client = Client::builder().build()?;
   let resp = client.get(url).send()?;
   Ok(resp)

--- a/lib/src/utils/mod.rs
+++ b/lib/src/utils/mod.rs
@@ -4,6 +4,5 @@
 //! Common utilities for things like parsing and IO.
 
 pub mod io;
-pub mod result;
 pub mod search;
 pub mod tokens;

--- a/lib/src/utils/result.rs
+++ b/lib/src/utils/result.rs
@@ -1,8 +1,0 @@
-#![warn(clippy::all)]
-
-//! Common types and utilities for error-handling.
-
-use std::error::Error;
-
-/// A shorthand type for library functions that may return errors.
-pub type Res<T = ()> = Result<T, Box<dyn Error>>;

--- a/lib/src/utils/search.rs
+++ b/lib/src/utils/search.rs
@@ -1,18 +1,15 @@
 //! A string type used to ensure that search keywords are lowercase and non-empty.
 
-use derive_more::Display;
-use std::error::Error;
+pub use self::Error as SearchStringError;
 
 /// Error type for search string construction.
-#[derive(Debug, Display)]
-#[display(fmt = "{}")]
-pub enum SearchStringErr {
+#[derive(Debug, thiserror::Error)]
+#[error("Search string error")]
+pub enum Error {
   /// Thrown if a search string is empty.
-  #[display(fmt = "Search title or keyword is empty")]
+  #[error("Search title or keyword is empty")]
   IsEmpty,
 }
-
-impl Error for SearchStringErr {}
 
 /// A string type used to ensure that search keywords are lowercase and non-empty.
 pub struct SearchString {
@@ -39,11 +36,11 @@ impl From<SearchString> for String {
 }
 
 impl TryFrom<&str> for SearchString {
-  type Error = SearchStringErr;
+  type Error = Error;
 
   fn try_from(value: &str) -> Result<Self, Self::Error> {
     if value.is_empty() {
-      return Err(SearchStringErr::IsEmpty);
+      return Err(Error::IsEmpty);
     }
 
     Ok(Self { contents: value.to_lowercase() })

--- a/lib/src/utils/tokens.rs
+++ b/lib/src/utils/tokens.rs
@@ -2,6 +2,15 @@
 
 //! Common utilities for writing parsers.
 
+/// General parsing errors.
+#[derive(Debug, thiserror::Error)]
+#[error("Parsing error")]
+pub enum Error {
+  /// Thrown if the end of file is reached unexpectedly.
+  #[error("Unexpected end of file")]
+  Eof,
+}
+
 /// Get the next iterator item or propagate an EOF error if the end is reached.
 ///
 /// This macro can be used when writing parsers that expect more input to be consumed
@@ -13,12 +22,12 @@
 ///
 /// # Errors
 ///
-/// * `Err::Eof` - Propagate an unexpected EOF error up the stack when the end of the
-/// iterator is reached. This should be expected behavior since this macro is used when
-/// a parser is expected to consume more input.
+/// * [`Error::Eof`] - Propagate an unexpected EOF error up the stack when the end of the
+/// iterator is reached. This should be expected behavior since this macro is used when a
+/// parser is expected to consume more input.
 #[macro_export]
 macro_rules! iter_next {
   ($iter:ident) => {{
-    $iter.next().ok_or(Err::Eof)?
+    $iter.next().ok_or($crate::utils::tokens::Error::Eof)
   }};
 }


### PR DESCRIPTION
This defines an `Err` enum for each module (using `thiserror`) and composes them. It gets rid of:
1. The `imdb::error` module.
2. The `utils::result` module and all uses of the old `Res<T>` type (`Result<T, Box<dyn Error>>`).