### PR TITLE
Fix clippy lints related to lifetimes and string formatting

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -40,7 +40,7 @@ enum TvRankErr {
   NoKeywords,
   #[display(fmt = "`{}` is not a directory", "_0.display()")]
   NotADirectory(PathBuf),
-  #[display(fmt = "Id `{}` was not found", _0)]
+  #[display(fmt = "Id `{_0}` was not found")]
   UnknownImdbId(String),
 }
 
@@ -213,7 +213,7 @@ enum Command {
 }
 
 fn display_title_and_year(title: &str, year: u16) -> String {
-  format!("{} ({})", title, year)
+  format!("{title} ({year})")
 }
 
 fn display_keywords(keywords: &[SearchString]) -> String {
@@ -244,9 +244,9 @@ fn create_keywords_set(title: &str) -> Res<Vec<SearchString>> {
   Ok(keywords)
 }
 
-fn imdb_title<'a>(
+fn imdb_title(
   title: &str,
-  imdb: &'a Imdb,
+  imdb: &Imdb,
   imdb_url: &Url,
   search_opts: &SearchOpts,
   exact: bool,
@@ -611,7 +611,7 @@ impl Context {
     let log_level = get_log_level(general_opts.verbose);
     let logger = env_logger::Builder::new().filter_level(log_level).try_init();
     if let Err(e) = &logger {
-      eprintln!("Error initializing logger: {}", e);
+      eprintln!("Error initializing logger: {e}");
     }
     let have_logger = logger.is_err();
 

--- a/cli/src/print.rs
+++ b/cli/src/print.rs
@@ -150,9 +150,9 @@ impl TablePrinter {
   ) -> Res {
     if results.is_empty() {
       if let Some(search_terms) = search_terms {
-        eprintln!("No {} matches found for `{search_terms}`", query);
+        eprintln!("No {query} matches found for `{search_terms}`");
       } else {
-        eprintln!("No {} matches found", query);
+        eprintln!("No {query} matches found");
       }
     } else {
       let num = results.total_len();
@@ -164,18 +164,14 @@ impl TablePrinter {
 
       if let Some(search_terms) = search_terms {
         if results.is_truncated() {
-          println!(
-            "Found {num} {} {matches} for `{search_terms}`, {} will be displayed:",
-            query,
-            results.len()
-          )
+          println!("Found {num} {query} {matches} for `{search_terms}`, {} will be displayed:", results.len())
         } else {
-          println!("Found {num} {} {matches} for `{search_terms}`:", query)
+          println!("Found {num} {query} {matches} for `{search_terms}`:")
         }
       } else if results.is_truncated() {
-        println!("Found {num} {} {matches}, {} will be displayed:", query, results.len());
+        println!("Found {num} {query} {matches}, {} will be displayed:", results.len());
       } else {
-        println!("Found {num} {} {matches}:", query);
+        println!("Found {num} {query} {matches}:");
       }
 
       let mut table = create_table(self.color);
@@ -207,7 +203,7 @@ impl TablePrinter {
     }
 
     if let Some(year) = title.start_year() {
-      row.add_cell(Cell::new(&format!("{}", year)));
+      row.add_cell(Cell::new(&format!("{year}")));
     } else {
       row.add_cell(Cell::new(""));
     }
@@ -241,9 +237,9 @@ impl TablePrinter {
     row.add_cell(Cell::new(&format!("{}", title.title_type())));
 
     let title_id = title.title_id();
-    row.add_cell(Cell::new(&format!("{}", title_id)));
+    row.add_cell(Cell::new(&format!("{title_id}")));
 
-    let url = imdb_url.join(&format!("{}", title_id))?;
+    let url = imdb_url.join(&format!("{title_id}"))?;
     row.add_cell(Cell::new(url.as_str()));
 
     Ok(row)

--- a/lib/examples/query.rs
+++ b/lib/examples/query.rs
@@ -11,16 +11,16 @@ fn main() -> Res {
   let title = "city of god";
   let year = 2002;
 
-  println!("Matches for {} and {:?}:", title, year);
+  println!("Matches for {title} and {year:?}:");
 
   let search_string = SearchString::try_from(title)?;
   for title in imdb.by_title_and_year(&search_string, year, ImdbQuery::Movies) {
     let id = title.title_id();
 
-    println!("ID: {}", id);
+    println!("ID: {id}");
     println!("Primary name: {}", title.primary_title());
     if let Some(original_title) = title.original_title() {
-      println!("Original name: {}", original_title);
+      println!("Original name: {original_title}");
     } else {
       println!("Original name: N/A");
     }

--- a/lib/src/imdb/db_binary.rs
+++ b/lib/src/imdb/db_binary.rs
@@ -1,3 +1,5 @@
+#![warn(clippy::all)]
+
 use super::db::Db;
 use crate::imdb::title::Title;
 use crate::imdb::title_id::TitleId;
@@ -98,7 +100,7 @@ impl ServiceDbFromBinary {
 
         let title = match Title::from_binary(&mut cursor_guard) {
           Ok(title) => title,
-          Err(e) => panic!("Error parsing title: {}", e),
+          Err(e) => panic!("Error parsing title: {e}"),
         };
 
         titles.push(title);
@@ -174,7 +176,7 @@ impl ServiceDbFromBinary {
       .collect()
   }
 
-  pub(crate) fn by_keywords<'a, 'k>(&'a self, keywords: &'k [SearchString], query: Query) -> Vec<&'a Title> {
+  pub(crate) fn by_keywords<'a>(&'a self, keywords: &[SearchString], query: Query) -> Vec<&'a Title> {
     self
       .dbs
       .par_iter()
@@ -182,9 +184,9 @@ impl ServiceDbFromBinary {
       .collect()
   }
 
-  pub(crate) fn by_keywords_and_year<'a, 'k>(
+  pub(crate) fn by_keywords_and_year<'a>(
     &'a self,
-    keywords: &'k [SearchString],
+    keywords: &[SearchString],
     year: u16,
     query: Query,
   ) -> Vec<&'a Title> {

--- a/lib/src/imdb/db_impl.rs
+++ b/lib/src/imdb/db_impl.rs
@@ -143,7 +143,7 @@ impl<C> DbImpl<C> {
   /// # Arguments
   ///
   /// * `keywords` - Keywords to search for in title names.
-  fn cookies_by_keywords<'a, 'k>(&'a self, keywords: &'k [SearchString]) -> impl Iterator<Item = &'a C> {
+  fn cookies_by_keywords<'a>(&'a self, keywords: &[SearchString]) -> impl Iterator<Item = &'a C> {
     let searcher = AhoCorasickBuilder::new().match_kind(ACMatchKind::LeftmostFirst).build(keywords);
     let keywords_len = keywords.len();
     self
@@ -163,9 +163,9 @@ impl<C> DbImpl<C> {
   ///
   /// * `keywords` - Keywords to search for in title names.
   /// * `year` - The year to search for titles in.
-  fn cookies_by_keywords_and_year<'a, 'k>(
+  fn cookies_by_keywords_and_year<'a>(
     &'a self,
-    keywords: &'k [SearchString],
+    keywords: &[SearchString],
     year: u16,
   ) -> impl Iterator<Item = &'a C> {
     let searcher = AhoCorasickBuilder::new().match_kind(ACMatchKind::LeftmostFirst).build(keywords);
@@ -245,10 +245,7 @@ impl<C: Into<usize> + Copy> DbImpl<C> {
   /// # Arguments
   ///
   /// * `keywords` - Keywords to search for.
-  pub(crate) fn by_keywords<'a, 'k>(
-    &'a self,
-    keywords: &'k [SearchString],
-  ) -> impl Iterator<Item = &'a Title> {
+  pub(crate) fn by_keywords<'a>(&'a self, keywords: &[SearchString]) -> impl Iterator<Item = &'a Title> {
     self.cookies_by_keywords(keywords).map(|&cookie| &self[cookie])
   }
 
@@ -258,9 +255,9 @@ impl<C: Into<usize> + Copy> DbImpl<C> {
   ///
   /// * `keywords` - Keywords to search for.
   /// * `year` - The year to search for titles in.
-  pub(crate) fn by_keywords_and_year<'a, 'k>(
+  pub(crate) fn by_keywords_and_year<'a>(
     &'a self,
-    keywords: &'k [SearchString],
+    keywords: &[SearchString],
     year: u16,
   ) -> impl Iterator<Item = &'a Title> {
     self.cookies_by_keywords_and_year(keywords, year).map(|&cookie| &self[cookie])

--- a/lib/src/imdb/error.rs
+++ b/lib/src/imdb/error.rs
@@ -10,13 +10,13 @@ use std::error::Error;
 #[display(fmt = "{}")]
 pub enum Err {
   /// Thrown if an ID does not start with `tt`
-  #[display(fmt = "ID `{}` does not start with `tt` (e.g. ttXXXXXXX)", _0)]
+  #[display(fmt = "ID `{_0}` does not start with `tt` (e.g. ttXXXXXXX)")]
   Id(String),
   /// Thrown if an ID does not contain a valid number
-  #[display(fmt = "ID `{}` does not contain a valid number (e.g. ttXXXXXXX)", _0)]
+  #[display(fmt = "ID `{_0}` does not contain a valid number (e.g. ttXXXXXXX)")]
   IdNumber(String),
   /// Thrown if the ID already exists
-  #[display(fmt = "Duplicate IMDB ID `{}` found", _0)]
+  #[display(fmt = "Duplicate IMDB ID `{_0}` found")]
   DuplicateId(String),
   /// Thrown if the given title type does not exist
   #[display(fmt = "Unknown title type")]
@@ -49,10 +49,10 @@ pub enum Err {
   #[display(fmt = "Error querying the IMDB basics DB")]
   BasicsDbQuery,
   /// Thrown if the given title type is not supported
-  #[display(fmt = "Unsupported title type `{}`", _0)]
+  #[display(fmt = "Unsupported title type `{_0}`")]
   UnsupportedTitleType(TitleType),
   /// Thrown if a problem occurs while parsing a title
-  #[display(fmt = "Error parsing title: {}", _0)]
+  #[display(fmt = "Error parsing title: {_0}")]
   ParsingTitle(String),
 }
 

--- a/lib/src/imdb/genre.rs
+++ b/lib/src/imdb/genre.rs
@@ -176,10 +176,10 @@ impl fmt::Display for Genres {
 
     for genre in self.iter() {
       if first {
-        write!(f, "{}", genre)?;
+        write!(f, "{genre}")?;
         first = false;
       } else {
-        write!(f, ", {}", genre)?;
+        write!(f, ", {genre}")?;
       }
     }
 

--- a/lib/src/imdb/service.rs
+++ b/lib/src/imdb/service.rs
@@ -157,7 +157,7 @@ impl Service {
   ///
   /// * `keywords` - List of keywords to search in titles.
   /// * `query` - Specifies if movies or series are queried.
-  pub fn by_keywords<'a, 'k>(&'a self, keywords: &'k [SearchString], query: Query) -> Vec<&'a Title> {
+  pub fn by_keywords<'a>(&'a self, keywords: &[SearchString], query: Query) -> Vec<&'a Title> {
     self.service_db.by_keywords(keywords, query)
   }
 
@@ -168,9 +168,9 @@ impl Service {
   /// * `keywords` - List of keywords to search in titles.
   /// * `year` - Release year of the title.
   /// * `query` - Specifies if movies or series are queried.
-  pub fn by_keywords_and_year<'a, 'k>(
+  pub fn by_keywords_and_year<'a>(
     &'a self,
-    keywords: &'k [SearchString],
+    keywords: &[SearchString],
     year: u16,
     query: Query,
   ) -> Vec<&'a Title> {


### PR DESCRIPTION
Clippy 1.67 warns about unnecessary explicit lifetimes and when string interpolation could be used instead of function arguments in string formatting routines.