### PR TITLE
Switch workspace resolver to 2021 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = ["lib", "cli"]
 default-members = ["lib", "cli"]
+resolver = "2"
 
 [profile.release]
 debug = false


### PR DESCRIPTION
By default cargo uses the old resolver for workspaces and using the new resolver needs to be explicitly set at the top-level. This comes due to the libraries and binary using the 2021 edition.