### PR TITLE
Fix rating sorting

### DIFF
--- a/cli/src/search.rs
+++ b/cli/src/search.rs
@@ -70,7 +70,7 @@ impl<'a, 'storage> SearchRes<'a, 'storage> {
   }
 
   pub fn extend(&mut self, iter: impl IntoIterator<Item = &'a ImdbTitle<'storage>>) {
-    self.results.extend(iter.into_iter())
+    self.results.extend(iter)
   }
 
   pub fn top_sorted_results(&mut self) -> &[&'a ImdbTitle<'storage>] {

--- a/lib/src/imdb/ratings.rs
+++ b/lib/src/imdb/ratings.rs
@@ -51,12 +51,7 @@ pub struct Rating {
 
 impl PartialOrd for Rating {
   fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-    match self.rating.partial_cmp(&other.rating) {
-      Some(Ordering::Equal) => {}
-      ord => return ord,
-    }
-
-    self.votes.partial_cmp(&other.votes)
+    Some(self.cmp(other))
   }
 }
 
@@ -67,7 +62,7 @@ impl Ord for Rating {
       ord => return ord,
     }
 
-    self.rating.cmp(&other.rating)
+    self.votes.cmp(&other.votes)
   }
 }
 


### PR DESCRIPTION
The sorting of ratings was incorrectly implemented. After comparing ratings, it should fall back to comparing votes, but instead it compared ratings again.