### PR TITLE
Fix documentation paragraph for Error::Eof

### DIFF
--- a/lib/src/utils/tokens.rs
+++ b/lib/src/utils/tokens.rs
@@ -23,8 +23,8 @@ pub enum Error {
 /// # Errors
 ///
 /// * [`Error::Eof`] - Propagate an unexpected EOF error up the stack when the end of the
-/// iterator is reached. This should be expected behavior since this macro is used when a
-/// parser is expected to consume more input.
+///   iterator is reached. This should be expected behavior since this macro is used when
+///   a parser is expected to consume more input.
 #[macro_export]
 macro_rules! iter_next {
   ($iter:ident) => {{


### PR DESCRIPTION
Just a doc update to fix [this](https://github.com/fredmorcos/tvrank/actions/runs/10690720092/job/29635737508?pr=102#step:5:324).