### PR TITLE
Move CI builds to latest versions of OSes to avoid indefinite queues

### DIFF
--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -32,7 +32,7 @@ jobs:
             'os': [
               {
                 'name': 'linux',
-                'edition': 'ubuntu-20.04',
+                'edition': 'ubuntu-22.04',
                 'execext': '',
                 'pkgext': '.tar.bz2',
                 'pkgcmd': ('tar -c -f '
@@ -50,7 +50,7 @@ jobs:
               },
               {
                 'name': 'macos',
-                'edition': 'macos-11',
+                'edition': 'macos-14',
                 'execext': '',
                 'pkgext': '.dmg',
                 'pkgcmd': ('hdiutil create -format UDZO -srcfolder '


### PR DESCRIPTION
CI is stalled on apparently old OS versions so let's always run on -latest. See #103.