### PR TITLE
Remove `enum-utils` and `failure` deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -202,7 +202,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn",
 ]
 
 [[package]]
@@ -316,7 +316,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.77",
+ "syn",
 ]
 
 [[package]]
@@ -395,30 +395,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "enum-utils"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed327f716d0d351d86c9fd3398d20ee39ad8f681873cc081da2ca1c10fed398a"
-dependencies = [
- "enum-utils-from-str",
- "failure",
- "proc-macro2",
- "quote",
- "serde_derive_internals",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "enum-utils-from-str"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d49be08bad6e4ca87b2b8e74146987d4e5cb3b7512efa50ef505b51a22227ee1"
-dependencies = [
- "proc-macro2",
- "quote",
-]
-
-[[package]]
 name = "env_logger"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -445,15 +421,6 @@ checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "failure"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d32e9bd16cc02eae7db7ef620b392808b89f6a5e16bb3497d159c6b92a0f4f86"
-dependencies = [
- "backtrace",
 ]
 
 [[package]]
@@ -964,7 +931,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn",
 ]
 
 [[package]]
@@ -1037,7 +1004,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn",
 ]
 
 [[package]]
@@ -1467,18 +1434,7 @@ checksum = "a5831b979fd7b5439637af1752d535ff49f4860c0f341d1baeb6faf0f4242170"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
-]
-
-[[package]]
-name = "serde_derive_internals"
-version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dbab34ca63057a1f15280bdf3c39f2b1eb1b54c17e98360e511637aef7418c6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
@@ -1566,17 +1522,6 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
-
-[[package]]
-name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
 
 [[package]]
 name = "syn"
@@ -1669,7 +1614,7 @@ checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn",
 ]
 
 [[package]]
@@ -1802,7 +1747,6 @@ dependencies = [
  "atoi",
  "derive_more",
  "deunicode",
- "enum-utils",
  "flate2",
  "fnv",
  "humantime",
@@ -1952,7 +1896,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
@@ -1986,7 +1930,7 @@ checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -2243,7 +2187,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn",
 ]
 
 [[package]]

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -28,7 +28,6 @@ flate2 = "1.0"
 humantime = "2.1"
 parking_lot = "0.12"
 log = "0.4"
-enum-utils = "0.1"
 url = "2.2"
 thiserror = "1.0"
 

--- a/lib/src/imdb/genre.rs
+++ b/lib/src/imdb/genre.rs
@@ -1,13 +1,13 @@
 #![warn(clippy::all)]
 
 use derive_more::Display;
-use enum_utils::FromStr;
 use serde::ser::SerializeSeq;
 use serde::{Serialize, Serializer};
 use std::fmt;
+use std::str::FromStr;
 
 /// 27 genres a title can be associated with
-#[derive(Debug, Display, FromStr, PartialEq, Eq, Hash, Clone, Copy, Serialize)]
+#[derive(Debug, Display, PartialEq, Eq, Hash, Clone, Copy, Serialize)]
 #[display(fmt = "{}")]
 pub enum Genre {
   /// Action
@@ -34,12 +34,10 @@ pub enum Genre {
   Fantasy = 10,
   /// FilmNoir
   #[display(fmt = "Film-Noir")]
-  #[enumeration(rename = "Film-Noir")]
   #[serde(rename(serialize = "Film-Noir"))]
   FilmNoir = 11,
   /// GameShow
   #[display(fmt = "Game-Show")]
-  #[enumeration(rename = "Game-Show")]
   #[serde(rename(serialize = "Game-Show"))]
   GameShow = 12,
   /// History
@@ -56,14 +54,12 @@ pub enum Genre {
   News = 18,
   /// RealityTv
   #[display(fmt = "Reality-TV")]
-  #[enumeration(rename = "Reality-TV")]
   #[serde(rename(serialize = "Reality-TV"))]
   RealityTv = 19,
   /// Romance
   Romance = 20,
   /// SciFi
   #[display(fmt = "Sci-Fi")]
-  #[enumeration(rename = "Sci-Fi")]
   #[serde(rename(serialize = "Sci-Fi"))]
   SciFi = 21,
   /// Short
@@ -72,7 +68,6 @@ pub enum Genre {
   Sport = 23,
   /// TalkShow
   #[display(fmt = "Talk-Show")]
-  #[enumeration(rename = "Talk-Show")]
   #[serde(rename(serialize = "Talk-Show"))]
   TalkShow = 24,
   /// Thriller
@@ -83,6 +78,45 @@ pub enum Genre {
   Western = 27,
   /// Experimental
   Experimental = 28,
+}
+
+impl FromStr for Genre {
+  type Err = ();
+
+  fn from_str(s: &str) -> Result<Self, Self::Err> {
+    match s {
+      "Action" => Ok(Genre::Action),
+      "Adult" => Ok(Genre::Adult),
+      "Adventure" => Ok(Genre::Adventure),
+      "Animation" => Ok(Genre::Animation),
+      "Biography" => Ok(Genre::Biography),
+      "Comedy" => Ok(Genre::Comedy),
+      "Crime" => Ok(Genre::Crime),
+      "Documentary" => Ok(Genre::Documentary),
+      "Drama" => Ok(Genre::Drama),
+      "Family" => Ok(Genre::Family),
+      "Fantasy" => Ok(Genre::Fantasy),
+      "Film-Noir" => Ok(Genre::FilmNoir),
+      "Game-Show" => Ok(Genre::GameShow),
+      "History" => Ok(Genre::History),
+      "Horror" => Ok(Genre::Horror),
+      "Music" => Ok(Genre::Music),
+      "Musical" => Ok(Genre::Musical),
+      "Mystery" => Ok(Genre::Mystery),
+      "News" => Ok(Genre::News),
+      "Reality-TV" => Ok(Genre::RealityTv),
+      "Romance" => Ok(Genre::Romance),
+      "Sci-Fi" => Ok(Genre::SciFi),
+      "Short" => Ok(Genre::Short),
+      "Sport" => Ok(Genre::Sport),
+      "Talk-Show" => Ok(Genre::TalkShow),
+      "Thriller" => Ok(Genre::Thriller),
+      "War" => Ok(Genre::War),
+      "Western" => Ok(Genre::Western),
+      "Experimental" => Ok(Genre::Experimental),
+      _ => Err(()),
+    }
+  }
 }
 
 impl Genre {

--- a/lib/src/imdb/title_type.rs
+++ b/lib/src/imdb/title_type.rs
@@ -1,13 +1,11 @@
 #![warn(clippy::all)]
 
 use derive_more::Display;
-use enum_utils::FromStr;
 use serde::Serialize;
-use std::hash::Hash;
+use std::{hash::Hash, str::FromStr};
 
 /// Encodes the 13 types of a title.
-#[derive(Debug, Display, FromStr, PartialEq, Eq, Hash, Clone, Copy, Serialize)]
-#[enumeration(rename_all = "camelCase")]
+#[derive(Debug, Display, PartialEq, Eq, Hash, Clone, Copy, Serialize)]
 #[display(fmt = "{}")]
 pub enum TitleType {
   // Games
@@ -52,6 +50,29 @@ pub enum TitleType {
   /// RadioSeries.
   #[display(fmt = "Radio Series")]
   RadioSeries = 12,
+}
+
+impl FromStr for TitleType {
+  type Err = ();
+
+  fn from_str(s: &str) -> Result<Self, Self::Err> {
+    match s {
+      "videoGame" => Ok(TitleType::VideoGame),
+      "short" => Ok(TitleType::Short),
+      "video" => Ok(TitleType::Video),
+      "movie" => Ok(TitleType::Movie),
+      "tvShort" => Ok(TitleType::TvShort),
+      "tvMovie" => Ok(TitleType::TvMovie),
+      "tvSpecial" => Ok(TitleType::TvSpecial),
+      "tvEpisode" => Ok(TitleType::TvEpisode),
+      "tvPilot" => Ok(TitleType::TvPilot),
+      "radioEpisode" => Ok(TitleType::RadioEpisode),
+      "tvSeries" => Ok(TitleType::TvSeries),
+      "tvMiniSeries" => Ok(TitleType::TvMiniSeries),
+      "radioSeries" => Ok(TitleType::RadioSeries),
+      _ => Err(()),
+    }
+  }
 }
 
 impl TitleType {


### PR DESCRIPTION
Github's been complaining about a security flaw in `failure`, which is also deprecated anyway, so let's move away from it.