### PR TITLE
Version 0.9.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Crates.io](https://img.shields.io/crates/v/tvrank?style=for-the-badge)](https://crates.io/crates/tvrank)
 [![CI](https://img.shields.io/github/actions/workflow/status/fredmorcos/tvrank/build-test-publish.yml?label=Main&style=for-the-badge)](https://github.com/fredmorcos/tvrank/actions)
 </br>
-[![docs.rs](https://img.shields.io/docsrs/tvrank?style=for-the-badge)](https://docs.rs/tvrank/0.8.5/tvrank/)
+[![docs.rs](https://img.shields.io/docsrs/tvrank?style=for-the-badge)](https://docs.rs/tvrank/0.9.0/tvrank/)
 [![Github Open Issues](https://img.shields.io/github/issues-raw/fredmorcos/tvrank?style=for-the-badge)](https://github.com/fredmorcos/tvrank/issues)
 [![Github Closed Issues](https://img.shields.io/github/issues-closed-raw/fredmorcos/tvrank?style=for-the-badge)](https://github.com/fredmorcos/tvrank/issues?q=is%3Aissue+is%3Aclosed)
 [![Github Open Pull Requests](https://img.shields.io/github/issues-pr-raw/fredmorcos/tvrank?style=for-the-badge)](https://github.com/fredmorcos/tvrank/pulls)

--- a/changelogs/0.9.0.md
+++ b/changelogs/0.9.0.md
@@ -1,0 +1,11 @@
+# Changes in `0.9.0`:
+
+* Dependency version updates.
+* Remove the `enum-utils` and `failure` crates as dependencies. The `failure` crate was a
+  dependency of `enum-utils` and has a security vulnerability which will not be fixed and
+  the crate is deprecated anyway. The `enum-utils` crate wasn't used much so it was
+  replaced with custom code.
+* Update to clap version 4 for the parsing command-line arguments.
+* Switch from `OpenSSL` to `rusTLS`. The former was causing linking problems on modern
+  Ubuntu systems.
+* Minor code and documentation cleanups and modernization.

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tvrank-cli"
-version = "0.8.5"
+version = "0.9.0"
 edition = "2021"
 description = "Query and sort information about movies and series"
 authors = ["Fred Morcos <fm@fredmorcos.com>"]
@@ -16,7 +16,7 @@ name = "tvrank"
 path = "src/main.rs"
 
 [dependencies]
-tvrank = { path = "../lib", version = "0.8.5" }
+tvrank = { path = "../lib", version = "0.9.0" }
 indicatif = "0.16"
 log = "0.4"
 atoi = "2.0"

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tvrank"
-version = "0.8.5"
+version = "0.9.0"
 edition = "2021"
 description = "Query and sort information about movies and series"
 authors = ["Fred Morcos <fm@fredmorcos.com>"]


### PR DESCRIPTION
# Changes in `0.9.0`:

* Dependency version updates.
* Remove the `enum-utils` and `failure` crates as dependencies. The `failure` crate was a dependency of `enum-utils` and has a security vulnerability which will not be fixed and the crate is deprecated anyway. The `enum-utils` crate wasn't used much so it was replaced with custom code.
* Update to clap version 4 for the parsing command-line arguments.
* Switch from `OpenSSL` to `rusTLS`. The former was causing linking problems on modern Ubuntu systems.
* Minor code and documentation cleanups and modernization.